### PR TITLE
feat: add per-user daily rate limit and message length cap to extract-character

### DIFF
--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -31,12 +31,36 @@ interface CharacterResponse {
   type: string;
 }
 
+// In-memory KV mock
+function createMockKV() {
+  const store = new Map<string, { value: string; expiry?: number }>();
+  return {
+    get: vi.fn(async (key: string) => {
+      const entry = store.get(key);
+      if (!entry) return null;
+      if (entry.expiry && Date.now() > entry.expiry) {
+        store.delete(key);
+        return null;
+      }
+      return entry.value;
+    }),
+    put: vi.fn(async (key: string, value: string, opts?: { expirationTtl?: number }) => {
+      const expiry = opts?.expirationTtl ? Date.now() + opts.expirationTtl * 1000 : undefined;
+      store.set(key, { value, expiry });
+    }),
+    _store: store,
+  };
+}
+
+const mockCache = createMockKV();
+
 const TEST_ENV = {
   TWITCH_CLIENT_ID: 'test-client-id',
   TWITCH_CLIENT_SECRET: 'test-client-secret',
   JWT_SECRET: 'test-jwt-secret-that-is-long-enough',
   FRONTEND_URL: 'https://example.com/app',
   GEMINI_API_KEY: 'test-gemini-key',
+  CACHE: mockCache,
 };
 
 // Helper to create a valid JWT
@@ -59,6 +83,7 @@ async function createTestToken(payload: Record<string, unknown> = {}, expiresIn 
 describe('Hono API', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCache._store.clear();
   });
 
   describe('CORS', () => {
@@ -226,6 +251,85 @@ describe('Hono API', () => {
       const body = await res.json() as CharacterResponse;
       expect(body.character).toBe('Meg Thomas');
       expect(body.type).toBe('survivor');
+    });
+
+    it('returns 400 when message exceeds 500 characters', async () => {
+      const token = await createTestToken();
+      const longMessage = 'a'.repeat(501);
+
+      const res = await app.request('/api/extract-character', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ message: longMessage }),
+      }, TEST_ENV);
+
+      expect(res.status).toBe(400);
+      const body = await res.json() as ErrorResponse & { max: number };
+      expect(body.error).toBe('message_too_long');
+      expect(body.max).toBe(500);
+    });
+
+    it('accepts message at exactly 500 characters', async () => {
+      const token = await createTestToken();
+      const exactMessage = 'a'.repeat(500);
+
+      const res = await app.request('/api/extract-character', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ message: exactMessage }),
+      }, TEST_ENV);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 429 when daily limit is exceeded', async () => {
+      const token = await createTestToken();
+
+      // Pre-fill the rate limit counter to the limit
+      const today = new Date().toISOString().slice(0, 10);
+      await mockCache.put(`ratelimit:extract:12345:${today}`, '200');
+
+      const res = await app.request('/api/extract-character', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ message: 'quero meg' }),
+      }, TEST_ENV);
+
+      expect(res.status).toBe(429);
+      const body = await res.json() as ErrorResponse & { limit: number };
+      expect(body.error).toBe('daily_limit_exceeded');
+      expect(body.limit).toBe(200);
+    });
+
+    it('increments rate limit counter after successful extraction', async () => {
+      const token = await createTestToken();
+
+      const res = await app.request('/api/extract-character', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ message: 'quero meg' }),
+      }, TEST_ENV);
+
+      expect(res.status).toBe(200);
+
+      const today = new Date().toISOString().slice(0, 10);
+      expect(mockCache.put).toHaveBeenCalledWith(
+        `ratelimit:extract:12345:${today}`,
+        '1',
+        { expirationTtl: 86400 }
+      );
     });
 
     it('returns 502 when Gemini fails', async () => {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -196,6 +196,10 @@ api.use("*", async (c, next) => {
   await next();
 });
 
+// Twitch chat messages are capped at 500 characters
+const MAX_MESSAGE_LENGTH = 500;
+const DAILY_EXTRACT_LIMIT = 200;
+
 api.post("/extract-character", async (c) => {
   const user = c.get("jwtPayload");
   const clientVersion = c.req.header("X-Client-Version") || "unknown";
@@ -205,10 +209,33 @@ api.post("/extract-character", async (c) => {
     return c.json({ error: "invalid_input" }, 400);
   }
 
+  if (body.message.length > MAX_MESSAGE_LENGTH) {
+    return c.json({ error: "message_too_long", max: MAX_MESSAGE_LENGTH }, 400);
+  }
+
+  // Per-user daily rate limit via KV
+  const today = new Date().toISOString().slice(0, 10);
+  const rateLimitKey = `ratelimit:extract:${user.sub}:${today}`;
+  const currentCount = parseInt((await c.env.CACHE.get(rateLimitKey)) || "0", 10);
+
+  if (currentCount >= DAILY_EXTRACT_LIMIT) {
+    console.warn(`[ratelimit] User ${user.login} (${user.sub}) hit daily extract limit of ${DAILY_EXTRACT_LIMIT}`);
+    return c.json({ error: "daily_limit_exceeded", limit: DAILY_EXTRACT_LIMIT }, 429);
+  }
+
   console.log(`[v${clientVersion}] Extract request from ${user.login}: ${body.message.slice(0, 100)}`);
 
   try {
     const result = await extractCharacter(body.message, c.env.GEMINI_API_KEY);
+
+    // Increment counter after successful extraction (TTL: 24h)
+    const putPromise = c.env.CACHE.put(rateLimitKey, String(currentCount + 1), { expirationTtl: 86400 });
+    try {
+      c.executionCtx.waitUntil(putPromise);
+    } catch {
+      await putPromise;
+    }
+
     return c.json(result);
   } catch (e: any) {
     console.error("Gemini error:", e.message);

--- a/apps/web/src/services/llm.ts
+++ b/apps/web/src/services/llm.ts
@@ -28,7 +28,12 @@ async function callAPI(
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      const msg = (err as any).message || (err as any).error || `HTTP ${res.status}`;
+      const errorCode = (err as any).error;
+      if (errorCode === 'daily_limit_exceeded') {
+        onError?.('Limite diário de identificações atingido');
+        return { character: '', type: 'none' };
+      }
+      const msg = (err as any).message || errorCode || `HTTP ${res.status}`;
       onError?.(msg);
       return { character: 'Erro na API', type: 'unknown' };
     }


### PR DESCRIPTION
- Limit input messages to 500 chars (Twitch chat maximum)
- Rate limit LLM extractions to 200 per user per day via KV counter
- Return 429 with daily_limit_exceeded when limit is hit
- Client handles daily limit error with user-friendly message

https://claude.ai/code/session_01NvQxwb9FdHLsAT1nzeDiK5