### PR TITLE
fix: prefer longer alias matches so "vecna novo" resolves to The First

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@ import { Stats } from './components/Stats';
 import { Toaster } from 'sonner';
 import { useWhatsNew } from './hooks/useWhatsNew';
 import { identifyCharacter } from './services';
+import { tryLocalMatch } from './data/characters';
 import { recoverMissedRequests, scanVODForRequests, type VODInfo } from './services/vod';
 import { DONATE_BOT_NAMES } from './services/twitch';
 import { toast } from 'sonner';
@@ -65,6 +66,27 @@ function useAutoIdentify(requests: Request[], update: (id: number, updates: Part
       identifyCharacter(req, undefined, (llmResult) => update(req.id, llmResult))
         .then(result => update(req.id, { ...result, needsIdentification: false }))
         .finally(() => inFlight.current.delete(req.id));
+    }
+  }, [requests, update, readOnly]);
+}
+
+// One-shot migration: re-runs the local matcher on existing non-manual requests
+// stuck on "Lich" (the previous regex incorrectly preferred the "Vecna" alias
+// of Lich over the longer "Vecna Novo"/"Vecna Stranger Things" aliases of
+// The First). Narrow on purpose to avoid clobbering manual edits.
+function useFixVecnaRegression(requests: Request[], update: (id: number, updates: Partial<Request>) => void, readOnly: boolean) {
+  const fixed = useRef(new Set<number>());
+  useEffect(() => {
+    if (readOnly) return;
+    for (const req of requests) {
+      if (fixed.current.has(req.id)) continue;
+      if (req.source === 'manual') continue;
+      if (req.character !== 'Lich') continue;
+      const rematch = tryLocalMatch(req.message);
+      if (rematch && rematch.character === 'The First') {
+        fixed.current.add(req.id);
+        update(req.id, { character: rematch.character, type: rematch.type, matchedTerm: rematch.matchedTerm });
+      }
     }
   }, [requests, update, readOnly]);
 }
@@ -290,6 +312,7 @@ function ChannelApp() {
   const hideNonRequests = useSources((s) => s.hideNonRequests);
 
   useAutoIdentify(requests, update, readOnly);
+  useFixVecnaRegression(requests, update, readOnly);
   useRequestToasts(requests, update, hideNonRequests);
   useWhatsNew(canControlConnection);
 

--- a/apps/web/src/data/characters.test.ts
+++ b/apps/web/src/data/characters.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { tryLocalMatch } from './characters';
+
+describe('tryLocalMatch', () => {
+  it('matches a single alias', () => {
+    expect(tryLocalMatch('quero huntress')).toMatchObject({ character: 'Huntress', type: 'killer' });
+  });
+
+  it('prefers longer multi-word alias over substring at same position', () => {
+    // "Vecna" matches both Lich and The First, but "Vecna Novo" should win for The First.
+    const result = tryLocalMatch('vecna novo');
+    expect(result).toMatchObject({ character: 'The First', type: 'killer' });
+    expect(result?.ambiguous).toBeFalsy();
+  });
+
+  it('still picks Lich for plain "vecna"', () => {
+    // Both Lich and The First list "Vecna" as alias; this stays ambiguous and
+    // last-encountered wins (Lich is iterated first, so kept after dedup).
+    const result = tryLocalMatch('quero vecna');
+    expect(result?.character).toBe('Lich');
+    expect(result?.ambiguous).toBe(true);
+  });
+});

--- a/packages/shared/src/characters.ts
+++ b/packages/shared/src/characters.ts
@@ -147,8 +147,20 @@ export function tryLocalMatch(message: string): LocalMatchResult | null {
         return null;
     }
 
-    const uniqueChars = new Set(matches.map(m => m.character));
-    const lastMatch = matches.reduce((a, b) => b.position > a.position ? b : a);
+    // Drop matches fully covered by a longer overlapping match, so multi-word
+    // aliases like "Vecna Novo" win over the substring "Vecna".
+    const filtered = matches.filter(m => {
+        const end = m.position + m.matchedTerm.length;
+        return !matches.some(other =>
+            other !== m &&
+            other.matchedTerm.length > m.matchedTerm.length &&
+            other.position <= m.position &&
+            other.position + other.matchedTerm.length >= end
+        );
+    });
+
+    const uniqueChars = new Set(filtered.map(m => m.character));
+    const lastMatch = filtered.reduce((a, b) => b.position > a.position ? b : a);
 
     return {
         character: lastMatch.character,


### PR DESCRIPTION
"Vecna" is an alias of both Lich and The First. With "vecna novo", both
matched at position 0 and the reduce kept the first one (Lich), losing
the more specific "Vecna Novo" alias. Now we drop matches fully covered
by a longer overlapping match before picking the latest, so multi-word
aliases win over their substrings.