### PR TITLE
fix: restrict request and sources toasts to streamer view only

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -91,14 +91,14 @@ function useFixVecnaRegression(requests: Request[], update: (id: number, updates
   }, [requests, update, readOnly]);
 }
 
-function useRequestToasts(requests: Request[], update: (id: number, updates: Partial<Request>) => void, hideNonRequests: boolean) {
+function useRequestToasts(requests: Request[], update: (id: number, updates: Partial<Request>) => void, hideNonRequests: boolean, readOnly: boolean) {
   const shownToasts = useRef(new Set<number>());
   const isFirstLoad = useRef(true);
   useEffect(() => {
     const ready = requests.filter(r => !shownToasts.current.has(r.id) && !r.needsIdentification);
     for (const req of ready) {
       shownToasts.current.add(req.id);
-      if (isFirstLoad.current) continue;
+      if (isFirstLoad.current || readOnly) continue;
       if (hideNonRequests && req.type === 'none') {
         const msg = req.message.length > 50 ? req.message.slice(0, 50) + '…' : req.message;
         toast(t('toast.ignored', { donor: req.donor, message: msg }), {
@@ -115,7 +115,7 @@ function useRequestToasts(requests: Request[], update: (id: number, updates: Par
       toast(title, { description: message });
     }
     if (ready.length > 0) isFirstLoad.current = false;
-  }, [requests, update, hideNonRequests]);
+  }, [requests, update, hideNonRequests, readOnly]);
 }
 
 function ChannelApp() {
@@ -313,7 +313,7 @@ function ChannelApp() {
 
   useAutoIdentify(requests, update, readOnly);
   useFixVecnaRegression(requests, update, readOnly);
-  useRequestToasts(requests, update, hideNonRequests);
+  useRequestToasts(requests, update, hideNonRequests, readOnly);
   useWhatsNew(canControlConnection);
 
   const pendingCount = requests.filter(d => !d.done && (!hideNonRequests || d.type !== 'none')).length;

--- a/apps/web/src/store/ChannelContext.tsx
+++ b/apps/web/src/store/ChannelContext.tsx
@@ -251,7 +251,7 @@ export function ChannelProvider({ channel, children }: ChannelProviderProps) {
             });
             return;
           }
-          if (msg.type === 'update-sources') {
+          if (msg.type === 'update-sources' && isOwnChannel) {
             const s = msg.sources;
             const parts: string[] = [];
             if (s.enabled.donation) parts.push(t('toast.sourcesDonations', { amount: String(s.minDonation) }));


### PR DESCRIPTION
## What changed

Toasts for **ignored donations**, **new requests**, and **sources configuration updates** were firing for all visitors to a channel page — not just the streamer managing their own queue.

### Root cause

- `useRequestToasts` in `App.tsx` had no owner check — it fired for every user regardless of `readOnly` state.
- The `update-sources` toast in `ChannelContext.tsx` was inside a generic message handler that ran for all connected users.

### Fix

**`apps/web/src/App.tsx`** — Add `readOnly: boolean` parameter to `useRequestToasts`. When `readOnly` is true (i.e. viewer), all toast notifications are suppressed. Seen IDs are still tracked so no stale toasts appear if ownership is gained later in the same session.

**`apps/web/src/store/ChannelContext.tsx`** — Guard the `update-sources` toast with `isOwnChannel` so only the streamer sees source configuration change notifications.

### Toasts audited (no other leaks found)

| Toast | Location | Status |
|---|---|---|
| Ignored donation / new request | `App.tsx` `useRequestToasts` | ✅ Fixed |
| Sources updated | `ChannelContext.tsx` | ✅ Fixed |
| What's new / changelog | `useWhatsNew` | ✅ Already guarded (`canControlConnection`) |
| IRC / PartyKit disconnect | `ChannelContext.tsx` | ✅ Already guarded (`isOwnChannel`) |
| Notifications blocked | `ChannelContext.tsx` | ✅ Already guarded (`isOwnChannel`) |
| Channel already open (multi-tab) | `ChannelContext.tsx` | ✅ Already guarded (`someoneElseIsOwner` implies `isOwnChannel`) |
| VOD recovery error | `App.tsx` | ✅ Already guarded (`canControlConnection`) |
| Service worker update | `main.tsx` | ✅ Intentionally shown to all users |
| Link copied | `ChannelHeader.tsx` | ✅ Intentionally shown to all users |
| Server error / version mismatch | `ChannelContext.tsx` | ✅ Intentionally shown to all users |