### PR TITLE
Multi-request donations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 .env
+.dev.vars
 .DS_Store
 .claude/settings.local.json
 .claude/skills/test-extraction/*.json

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You need to keep the site open to receive requests.
 
 | Source | How it works |
 |--------|-------------|
-| **Donations** | Detects messages from donation bots (LivePix, StreamElements, etc.). Filters by minimum amount |
+| **Donations** | Detects messages from donation bots (LivePix, StreamElements, etc.). Filters by minimum amount. Donations that exceed the minimum may contain multiple requests in one message (up to 10) |
 | **Resubs** | Captures resub messages via Twitch IRC USERNOTICE |
 | **Chat** | Configurable command (default: `!fila`) for subscribers. Filters by minimum tier |
 | **Manual** | Manual character entry |
@@ -187,7 +187,7 @@ Use o nosso [Discord](https://discord.gg/6pY7Efhxd) ou o próprio GitHub para ma
 
 | Fonte | Como funciona |
 |-------|---------------|
-| **Donates** | Detecta mensagens de bots de doação (LivePix, StreamElements, etc.). Filtra por valor mínimo |
+| **Donates** | Detecta mensagens de bots de doação (LivePix, StreamElements, etc.). Filtra por valor mínimo. Donates acima do mínimo podem conter múltiplos pedidos numa mesma mensagem (até 10) |
 | **Resubs** | Captura mensagens de resub via USERNOTICE do Twitch IRC |
 | **Chat** | Comando configurável (padrão: `!fila`) para inscritos. Filtra por tier mínimo |
 | **Manual** | Entrada manual de personagens |

--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ To test StreamElements format:
 dbdDebug.raw('@display-name=StreamElements :streamelements!streamelements@streamelements.tmi.twitch.tv PRIVMSG #ch :Donor mandou 5.00 e disse: Huntress')
 ```
 
+### LLM extraction evals
+
+Live evals against the real Gemini API live in `apps/api/src/gemini.eval.test.ts`. They are skipped by the default test suite (and by CI) and run on demand:
+
+```bash
+cd apps/api
+set -a && source .env && set +a   # load GEMINI_API_KEY
+bun run test:eval
+```
+
+Scenarios are sampled from real anonymized donation messages and cover single-character nicknames, no-request messages, and multi-character requests (including quantifiers like "2 de trapper e 1 de nurse"). Comparison is multiset — order doesn't matter, duplicates do. Add new cases to the file when a new edge case surfaces in production.
+
 ## License
 
 MIT ([LICENSE](LICENSE))

--- a/apps/api/migrations/0006_add_origin_msg_id.sql
+++ b/apps/api/migrations/0006_add_origin_msg_id.sql
@@ -1,0 +1,4 @@
+-- Track which donation a request came from so multi-request donations can
+-- be grouped in the UI. Nullable: existing rows and non-donation rows stay NULL.
+ALTER TABLE requests ADD COLUMN origin_msg_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_requests_origin_msg_id ON requests(origin_msg_id);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,8 @@
     "tail:party": "partykit tail",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:eval": "RUN_EVALS=1 vitest run gemini.eval"
   },
   "dependencies": {
     "@dbd-utils/shared": "workspace:*",

--- a/apps/api/src/gemini.eval.test.ts
+++ b/apps/api/src/gemini.eval.test.ts
@@ -1,0 +1,286 @@
+// Live LLM evals for the Gemini character extractor.
+//
+// These tests hit the real Gemini API and verify that the prompt + model
+// combination correctly identifies characters in real-world donation messages.
+//
+// Skipped by default. To run:
+//
+//   RUN_EVALS=1 GEMINI_API_KEY=... bun run --filter @dbd-utils/api test -- gemini.eval
+//   # or, with the env var already set in apps/api/.env:
+//   RUN_EVALS=1 bun run --filter @dbd-utils/api test -- gemini.eval
+//
+// Scenarios were sampled and lightly anonymized from real production donation
+// messages on the @mandymess channel. Streamer-specific terms have been replaced
+// with the generic placeholder "{{streamer}}"; bystander names have been replaced
+// with fictitious initials. The semantic structure that the LLM must reason about
+// (nicknames, quantifiers, long context, embedded requests) is preserved verbatim.
+//
+// Pass criterion: multiset equality — the array of returned character names must
+// match `expected` regardless of order. This tolerates LLM variation in which
+// character is listed first while still catching missed or fabricated entries.
+
+import { describe, it, expect } from 'vitest';
+import { extractCharacters } from './gemini';
+
+// `process` isn't in the worker tsconfig lib but is available at runtime
+// because vitest runs this file in a Node environment.
+declare const process: { env: Record<string, string | undefined> };
+
+const RUN_EVALS = !!process.env.RUN_EVALS;
+
+interface EvalCase {
+  name: string;
+  message: string;
+  maxCount: number;
+  expected: string[]; // character names; empty = LLM should return no characters
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Single-character scenarios
+// ──────────────────────────────────────────────────────────────────────────────
+const singleCases: EvalCase[] = [
+  {
+    name: 'single / nickname: Drácula → Dark Lord',
+    message: 'Boa noite lindeza, tudo bem? Joga de Drácula, se puder, menor que três',
+    maxCount: 1,
+    expected: ['Dark Lord'],
+  },
+  {
+    name: 'single / nickname: draga → Dredge',
+    message: 'amiga, será q rola uma draga mais tarde?',
+    maxCount: 1,
+    expected: ['Dredge'],
+  },
+  {
+    name: 'single / nickname: pirâmide → Pyramid Head',
+    message: 'Oi {{streamer}}, tudo bom? Passando pra dar boa noite, pedi um pirâmide, tá bom? Beijo, boa live.',
+    maxCount: 1,
+    expected: ['Pyramid Head'],
+  },
+  {
+    name: 'single / nickname: Sadako do Olhão → Onryō',
+    message: '{{streamer}}, joga uma de Sadako do Olhão pra gente.',
+    maxCount: 1,
+    expected: ['Onryō'],
+  },
+  {
+    name: 'single / nickname: kanekizinho → Ghoul',
+    message: '{{streamer}} {{streamer}}nha poderia dar uma jogadinha do kanekizinho com buildzinha de velocidadezinha',
+    maxCount: 1,
+    expected: ['Ghoul'],
+  },
+  {
+    name: 'single / nickname: huntrex → Huntress',
+    message: 'Vamos barbarizar uma de huntrex',
+    maxCount: 1,
+    expected: ['Huntress'],
+  },
+  {
+    name: 'single / nickname: Espectro → Wraith',
+    message: 'Boa noite {{streamer}}, joga de Espectro com a nova skin do passe quando vc liberar ela <3 te amo',
+    maxCount: 1,
+    expected: ['Wraith'],
+  },
+  {
+    name: 'single / nickname: wesker → Mastermind',
+    message: 'Boa noite, ta bem? Ta aceitando pedido? Se tiver joga de wesker por favor. E eu nao dei sub pq esta bufado, nao está indo nem pelo site.',
+    maxCount: 1,
+    expected: ['Mastermind'],
+  },
+  {
+    name: 'single / nickname: Myers → Shape (only Myers mentioned)',
+    message: 'Boa noite! Vai uma Myers por favor. Um beijo!',
+    maxCount: 1,
+    expected: ['Shape'],
+  },
+  {
+    name: 'single / nickname: trick trick trans → Trickster',
+    message: '{{streamer}}, o que você tem a falar sobre a situação atual da R.? Vocês jogavam juntas e acho que eram amigas.. você está ajudando ela ou sabe se tem algum apoio? Joga de Trick trick trans',
+    maxCount: 1,
+    expected: ['Trickster'],
+  },
+  {
+    name: 'single / nickname: Vecna novo → The First (Stranger Things crossover)',
+    message: 'Oi {{streamer}}, passando pra dizer que adoro você, joga de Vecna novo',
+    maxCount: 1,
+    expected: ['The First'],
+  },
+  {
+    name: 'single / nickname: Vecna do D&D → Lich (original D&D Vecna)',
+    message: 'Vai uma de Vecna do D e D por favor',
+    maxCount: 1,
+    expected: ['Lich'],
+  },
+  {
+    name: 'single / nickname: Adriana → Skull Merchant',
+    message: 'Te amo irma, um beijo de Londres <3 Joga de Adriana! Minha rainha destruida.',
+    maxCount: 1,
+    expected: ['Skull Merchant'],
+  },
+  {
+    name: 'single / nickname: Alien → Xenomorph',
+    message: 'Bora de Alien, com a mais babadeira do DBD.',
+    maxCount: 1,
+    expected: ['Xenomorph'],
+  },
+  {
+    name: 'single / long context, request at end: Oni',
+    message: 'Bate bola jogo rápido! Um tom pantone? Uma marca de roupa? Um champion do Lol AD? Um surv? E um killer? ERRADO!!! JOGA DE Oni',
+    maxCount: 1,
+    expected: ['Oni'],
+  },
+  {
+    name: 'single / embedded request among noise: Hag',
+    message: 'Oi {{streamer}}, joga uma de hag com a skin de madame frost com uma Build de frankilin para acabar com esses achismo na área dos geladinhos. Pense gelado, pense hag!',
+    maxCount: 1,
+    expected: ['Hag'],
+  },
+  {
+    name: 'single / request despite another character name in noise: Trickster (krasue is current killer reference, not request)',
+    message: 'joga 1 trickster então pra despedir do muso tapete da krasue.',
+    maxCount: 1,
+    expected: ['Trickster'],
+  },
+  {
+    name: 'single / Krasue nickname: kraseu → Krasue',
+    message: 'puxa uma kraseu pa tropa, lindão. lethal, dissolution, bambas e bbq. cabeça de galinha e olho de porco de addon pro churras. amo vc tmj',
+    maxCount: 1,
+    expected: ['Krasue'],
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Scenarios that should produce zero characters (no actual play request)
+// ──────────────────────────────────────────────────────────────────────────────
+const noneCases: EvalCase[] = [
+  {
+    name: 'none / personal venting, no request',
+    message: '{{streamer}}, boa noite. desabafo leve. to ansioso hoje porque amanhã começa uma jornada nova na minha vida. vou pra sp fazer minha especialização e trabalhar pesado ao mesmo tempo. sei que vou dar conta mas ao mesmo tempo dá uma ansiedade maluca e um medo',
+    maxCount: 1,
+    expected: [],
+  },
+  {
+    name: 'none / movie request, not DBD',
+    message: 'Boa noite, posso te fazer uma proposta? Queria muito te ver assistindo O Diabo Veste Prada, tô muito ansioso pro 2',
+    maxCount: 2,
+    expected: [],
+  },
+  {
+    name: 'none / birthday greeting',
+    message: 'Quem é o aniversariante mais lindo, mais maravilhoso e cheio de carisma do dia? Te amo meu amor, espero que vc tenha um novo ciclo cheio de amor, sucesso e muitas conquistas.',
+    maxCount: 1,
+    expected: [],
+  },
+  {
+    name: 'none / shoutout, no character',
+    message: 'BORA BARBARIZAR',
+    maxCount: 1,
+    expected: [],
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Multi-character scenarios (the new feature)
+// ──────────────────────────────────────────────────────────────────────────────
+const multiCases: EvalCase[] = [
+  {
+    name: 'multi / "uma de X e uma de Y" (real prod msg)',
+    message: 'Oi {{streamer}}, joga uma de pig e uma de hag. Obrigado',
+    maxCount: 2,
+    expected: ['Pig', 'Hag'],
+  },
+  {
+    name: 'multi / quantifier "duas de" → 2 of same character',
+    message: 'Oiii {{streamer}}! Cê tá maravilhosa, como sempre. Hoje assisti uma gameplay de Detroit e achei tudo. Joga duas de Chucky, por favor!',
+    maxCount: 2,
+    expected: ['Good Guy', 'Good Guy'],
+  },
+  {
+    name: 'multi / quantifier "3" → 3 of same character',
+    message: 'joga 3 trickster então pra fechar a noite, beijos',
+    maxCount: 3,
+    expected: ['Trickster', 'Trickster', 'Trickster'],
+  },
+  {
+    name: 'multi / two distinct nicknames: Adriana + Alien',
+    message: 'Boa noite {{streamer}}, tá pedindo uma Adriana e um Alien de musas.',
+    maxCount: 2,
+    expected: ['Skull Merchant', 'Xenomorph'],
+  },
+  {
+    name: 'multi / two distinct nicknames in long message: Ghost Face + Singularity',
+    message: 'Boa noite minha ancestral, minha tuntancamon, minha mao ze dong, minha Hamurabi, joga uma de Ghost face e uma de singularidade, beijos',
+    maxCount: 2,
+    expected: ['Ghost Face', 'Singularity'],
+  },
+  {
+    name: 'multi / "vecna novo" + "dracula" (both nicknames map to different chars)',
+    message: 'pois joga uma de vecna novo e uma de dracula',
+    maxCount: 2,
+    expected: ['The First', 'Dark Lord'],
+  },
+  {
+    name: 'multi / "vecna antigo" + singularidade',
+    message: 'Agora joga com killers que nos vestem: maceta uma singularidade e um vecna antigo, beijos',
+    maxCount: 2,
+    expected: ['Singularity', 'Lich'],
+  },
+  {
+    name: 'multi / Vecna + Myers (real prod msg, paid 10 with min 5)',
+    message: 'Boa noite mamis! Vai uma de Vecna do D e D que meu maridinho pediu e uma Myers por favor. Um beijo!',
+    maxCount: 2,
+    expected: ['Lich', 'Shape'],
+  },
+  {
+    name: 'multi / quantifier + extra: "2 de trapper e 1 de nurse"',
+    message: 'oie {{streamer}}, joga 2 de trapper e 1 de nurse por favor',
+    maxCount: 3,
+    expected: ['Trapper', 'Trapper', 'Nurse'],
+  },
+  {
+    name: 'multi / cap enforcement: user requests 3 but maxCount=2 → first 2',
+    message: 'joga uma de pig, uma de hag e uma de nurse',
+    maxCount: 2,
+    expected: ['Pig', 'Hag'],
+  },
+  {
+    name: 'multi / under-asks vs entitlement: user requests 1 but maxCount=3',
+    message: 'pode jogar uma de Spirit por favor',
+    maxCount: 3,
+    expected: ['Spirit'],
+  },
+  {
+    // KNOWN FAILURE — surfaced by these evals.
+    // The LLM currently returns ['Krasue', 'Trickster'] for this message:
+    // it correctly picks up "Trickster" but misses the "3" quantifier AND
+    // wrongly treats the trailing reference to "krasue" (the current/previous
+    // killer being played, mentioned only as context) as a separate request.
+    // Action item: tighten the prompt language around quantifiers when other
+    // character names are present in non-request positions in the sentence.
+    name: 'multi / current-killer reference is NOT a request: "tapete da krasue" + "joga 3 trickster"',
+    message: 'joga 3 trickster então pra despedir do muso tapete da krasue.',
+    maxCount: 3,
+    expected: ['Trickster', 'Trickster', 'Trickster'],
+  },
+];
+
+const allCases = [...singleCases, ...noneCases, ...multiCases];
+
+function multisetSorted(arr: string[]): string[] {
+  return [...arr].sort();
+}
+
+describe('Gemini extractCharacters — live LLM evals', () => {
+  it.skipIf(!RUN_EVALS).each(allCases)('$name', async ({ message, maxCount, expected }) => {
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      throw new Error('Set GEMINI_API_KEY (e.g. in apps/api/.env or .dev.vars) to run evals');
+    }
+
+    const result = await extractCharacters(message, apiKey, maxCount);
+    const names = result.map((r) => r.character);
+
+    // Multiset comparison: order doesn't matter, duplicates do.
+    expect(multisetSorted(names)).toEqual(multisetSorted(expected));
+  }, 30_000);
+});

--- a/apps/api/src/gemini.eval.test.ts
+++ b/apps/api/src/gemini.eval.test.ts
@@ -250,13 +250,11 @@ const multiCases: EvalCase[] = [
     expected: ['Spirit'],
   },
   {
-    // KNOWN FAILURE — surfaced by these evals.
-    // The LLM currently returns ['Krasue', 'Trickster'] for this message:
-    // it correctly picks up "Trickster" but misses the "3" quantifier AND
-    // wrongly treats the trailing reference to "krasue" (the current/previous
-    // killer being played, mentioned only as context) as a separate request.
-    // Action item: tighten the prompt language around quantifiers when other
-    // character names are present in non-request positions in the sentence.
+    // Regression watch: the LLM used to return ['Krasue', 'Trickster'] here —
+    // it missed the "3" quantifier and treated the contextual "krasue"
+    // reference (the current killer the user is saying goodbye to) as a
+    // separate request. Fixed by reframing the prompt around the user's
+    // command/intent and excluding context-only mentions.
     name: 'multi / current-killer reference is NOT a request: "tapete da krasue" + "joga 3 trickster"',
     message: 'joga 3 trickster então pra despedir do muso tapete da krasue.',
     maxCount: 3,
@@ -270,8 +268,8 @@ function multisetSorted(arr: string[]): string[] {
   return [...arr].sort();
 }
 
-describe('Gemini extractCharacters — live LLM evals', () => {
-  it.skipIf(!RUN_EVALS).each(allCases)('$name', async ({ message, maxCount, expected }) => {
+describe.concurrent('Gemini extractCharacters — live LLM evals', () => {
+  it.skipIf(!RUN_EVALS).concurrent.each(allCases)('$name', async ({ message, maxCount, expected }) => {
     const apiKey = process.env.GEMINI_API_KEY;
     if (!apiKey) {
       throw new Error('Set GEMINI_API_KEY (e.g. in apps/api/.env or .dev.vars) to run evals');

--- a/apps/api/src/gemini.ts
+++ b/apps/api/src/gemini.ts
@@ -44,8 +44,9 @@ ${message}
 Return ONLY JSON with a "characters" array. Each entry has character name, type, and the exact matched substring.
 - Return characters in the order they appear in the message.
 - The character name MUST be the official name (the first name in the slash-separated list above). e.g. "Myers" → "Shape".
-- Honor quantifiers: "2 de trapper" → two entries for "Trapper"; "1 nurse" → one entry for "Nurse".
-- Only extract characters the user is clearly requesting to play. Patterns like "joga de X", "vai de X", "uma de X", "play X", or a standalone character name as a request. Personal stories, questions, greetings, or general conversation should return an empty array — do NOT guess from vague context, metaphors, or unrelated words.
+- Extract ONLY the characters the user is COMMANDING the streamer to play (the user's request/order). A numeric quantifier attached to a name multiplies that specific name: "2 de trapper" → ["Trapper","Trapper"]; "3 trickster" → ["Trickster","Trickster","Trickster"]. The count never splits across other character names.
+- Character names mentioned only as CONTEXT (the streamer's current/past killer, comparisons, complaints, memories, e.g. "tapete da X", "chega de X", "depois da X") are not part of the user's command — exclude them. Example: "joga 3 trickster pra despedir da krasue" → ["Trickster","Trickster","Trickster"] (krasue = what's currently being played, not requested).
+- No command present (small talk, greetings, personal stories, off-topic donations) → empty array.
 - Cap the total returned at max_count. If the user requests more, return the first max_count in message order. If the user requests fewer, return only what they asked for — do NOT pad to max_count.
 - If the user requests a generic survivor ("joga de surv", "uma de survivor"), return one entry with character "Survivor" and type "survivor".
 - Recognize creative spellings, slang, and affectionate variations (e.g. "Drakuluxuuu" = Dracula, "demogogo" = Demogorgon, "pigzinha" = Pig).

--- a/apps/api/src/gemini.ts
+++ b/apps/api/src/gemini.ts
@@ -13,18 +13,19 @@ export type ExtractionResult = {
   matchedTerm?: string;
 };
 
-export async function extractCharacter(
+export async function extractCharacters(
   message: string,
   apiKey: string,
+  maxCount: number,
   attempt = 0,
   modelIdx = currentModelIndex,
   startIdx = currentModelIndex
-): Promise<ExtractionResult> {
+): Promise<ExtractionResult[]> {
   const model = MODELS[modelIdx];
 
-  console.log(`[extract] Starting extraction using model: ${model} (attempt ${attempt + 1}/${MAX_RETRIES + 1})`);
+  console.log(`[extract] Starting extraction using model: ${model} (attempt ${attempt + 1}/${MAX_RETRIES + 1}, maxCount=${maxCount})`);
 
-  const prompt = `Identify the Dead by Daylight character from the user message. This is the list of valid characters, although the user might not specify them exactly as on this list.
+  const prompt = `Identify Dead by Daylight characters requested in the user message. The user may request multiple characters. This is the list of valid characters, although the user might not specify them exactly as on this list.
 
 <survivors>
 ${DEFAULT_CHARACTERS.survivors.join('\n')}
@@ -38,19 +39,18 @@ ${DEFAULT_CHARACTERS.killers.join('\n')}
 ${message}
 </user_message>
 
-Identify the Dead by Daylight character from the above user message. Return ONLY JSON with character name and type.
-- The character name MUST be their official name, which is the first name in the slash-separated list provided above
-  - e.g. Even if the message mentions "Myers", return "Shape", not "Michael Myers".
-- Only extract a character if the user is clearly requesting one to play. Look for patterns like "joga de X", "vai de X", "uma de X", "play X", or a character name stated as a standalone request.
-- Messages that are personal stories, questions, greetings, or general conversation WITHOUT a gameplay request should return type "none" — do NOT guess a character from vague context, metaphors, or unrelated words.
-- If the text mentions multiple characters, determine by the intent of the message which ONE the user actually wants to play with or is requesting.
-  - e.g. "I love pig, but play one with hag" should return "Hag".
-  - e.g. "chega de Hag! Joga de Pinhead" should return "Cenobite" (Pinhead), not "Hag".
-- If user requests a generic survivor (e.g. "joga de surv", "uma de survivor"), return character "Survivor" with type "survivor".
-- Recognize creative spellings, slang, and affectionate variations of character names (e.g. "Drakuluxuuu" = Dracula, "demogogo" = Demogorgon, "pigzinha" = Pig).
-- If exact character unknown, return empty character.
-- If no character mentioned or requested, return type "none".
-- In "matchedTerm", return the EXACT substring from the user message that refers to the character, preserving the original casing and spelling (e.g. if the message says "Drácula", return "Drácula"; if "death slinger", return "death slinger").`;
+<max_count>${maxCount}</max_count>
+
+Return ONLY JSON with a "characters" array. Each entry has character name, type, and the exact matched substring.
+- Return characters in the order they appear in the message.
+- The character name MUST be the official name (the first name in the slash-separated list above). e.g. "Myers" → "Shape".
+- Honor quantifiers: "2 de trapper" → two entries for "Trapper"; "1 nurse" → one entry for "Nurse".
+- Only extract characters the user is clearly requesting to play. Patterns like "joga de X", "vai de X", "uma de X", "play X", or a standalone character name as a request. Personal stories, questions, greetings, or general conversation should return an empty array — do NOT guess from vague context, metaphors, or unrelated words.
+- Cap the total returned at max_count. If the user requests more, return the first max_count in message order. If the user requests fewer, return only what they asked for — do NOT pad to max_count.
+- If the user requests a generic survivor ("joga de surv", "uma de survivor"), return one entry with character "Survivor" and type "survivor".
+- Recognize creative spellings, slang, and affectionate variations (e.g. "Drakuluxuuu" = Dracula, "demogogo" = Demogorgon, "pigzinha" = Pig).
+- If a character is referenced but the exact identity is unknown, use empty string for character with the best-guess type.
+- In "matchedTerm", return the EXACT substring referring to that specific instance, preserving the original casing and spelling. If the same character is requested twice with the same wording, both entries may share the same matchedTerm.`;
 
   const res = await fetch(
     `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`,
@@ -68,11 +68,20 @@ Identify the Dead by Daylight character from the above user message. Return ONLY
           responseSchema: {
             type: 'object',
             properties: {
-              character: { type: 'string' },
-              type: { type: 'string', enum: ['survivor', 'killer', 'none'] },
-              matchedTerm: { type: 'string' },
+              characters: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    character: { type: 'string' },
+                    type: { type: 'string', enum: ['survivor', 'killer', 'none'] },
+                    matchedTerm: { type: 'string' },
+                  },
+                  required: ['character', 'type'],
+                },
+              },
             },
-            required: ['character', 'type'],
+            required: ['characters'],
           },
         },
       }),
@@ -90,12 +99,12 @@ Identify the Dead by Daylight character from the above user message. Return ONLY
       if (nextIdx !== startIdx) {
         console.log(`[extract] Switching from ${model} to ${MODELS[nextIdx]}`);
         currentModelIndex = nextIdx;
-        return extractCharacter(message, apiKey, 0, nextIdx, startIdx);
+        return extractCharacters(message, apiKey, maxCount, 0, nextIdx, startIdx);
       }
       if (attempt < MAX_RETRIES) {
         console.log(`[extract] Retrying in ${RETRY_DELAYS[attempt]}ms (attempt ${attempt + 2}/${MAX_RETRIES + 1})`);
         await new Promise((r) => setTimeout(r, RETRY_DELAYS[attempt]));
-        return extractCharacter(message, apiKey, attempt + 1, modelIdx, startIdx);
+        return extractCharacters(message, apiKey, maxCount, attempt + 1, modelIdx, startIdx);
       }
       console.error(`[extract] All retries exhausted after ${MAX_RETRIES + 1} attempts`);
     }
@@ -118,19 +127,20 @@ Identify the Dead by Daylight character from the above user message. Return ONLY
     if (nextIdx !== startIdx) {
       console.log(`[extract] Switching from ${model} to ${MODELS[nextIdx]}`);
       currentModelIndex = nextIdx;
-      return extractCharacter(message, apiKey, 0, nextIdx, startIdx);
+      return extractCharacters(message, apiKey, maxCount, 0, nextIdx, startIdx);
     }
     if (attempt < MAX_RETRIES) {
       console.log(`[extract] Retrying in ${RETRY_DELAYS[attempt]}ms (attempt ${attempt + 2}/${MAX_RETRIES + 1})`);
       await new Promise((r) => setTimeout(r, RETRY_DELAYS[attempt]));
-      return extractCharacter(message, apiKey, attempt + 1, modelIdx, startIdx);
+      return extractCharacters(message, apiKey, maxCount, attempt + 1, modelIdx, startIdx);
     }
 
     console.error(`[extract] All retries exhausted, returning empty`);
-    return { character: '', type: 'none' };
+    return [];
   }
 
-  const result = JSON.parse(text) as ExtractionResult;
-  console.log(`[extract] Success: character="${result.character}" type="${result.type}"`);
-  return result;
+  const parsed = JSON.parse(text) as { characters?: ExtractionResult[] };
+  const characters = Array.isArray(parsed.characters) ? parsed.characters.slice(0, maxCount) : [];
+  console.log(`[extract] Success: ${characters.length} character(s): ${characters.map(c => c.character).join(', ')}`);
+  return characters;
 }

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -556,6 +556,47 @@ describe('Hono API', () => {
       expect(markDoneSql).toBeUndefined();
     });
 
+    it('persists origin_msg_id in the upsert SQL and bindings', async () => {
+      const requests = [
+        {
+          id: 1001, timestamp: '2024-01-01T00:00:00Z', donor: 'A', amount: 'R$10',
+          amountVal: 10, message: 'Trapper e Nurse', character: 'Trapper', type: 'killer',
+          source: 'donation', needsIdentification: false, originMsgId: 'twitch-msg-abc',
+        },
+      ];
+
+      const res = await app.request('/internal/rooms/testroom/requests', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: internalAuth },
+        body: JSON.stringify({ requests, mode: 'partial' }),
+      }, TEST_ENV);
+
+      expect(res.status).toBe(200);
+      const upsert = mockDB._statements.find(s => s.sql.includes('INSERT INTO requests'));
+      expect(upsert).toBeDefined();
+      expect(upsert!.sql).toContain('origin_msg_id');
+      expect(upsert!.sql).toContain('origin_msg_id = excluded.origin_msg_id');
+      expect(upsert!.bindings).toContain('twitch-msg-abc');
+    });
+
+    it('binds null origin_msg_id when not provided', async () => {
+      const requests = [
+        { id: 2001, timestamp: '2024-01-01T00:00:00Z', donor: 'B', source: 'chat' },
+      ];
+
+      const res = await app.request('/internal/rooms/testroom/requests', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: internalAuth },
+        body: JSON.stringify({ requests, mode: 'partial' }),
+      }, TEST_ENV);
+
+      expect(res.status).toBe(200);
+      const upsert = mockDB._statements.find(s => s.sql.includes('INSERT INTO requests'));
+      expect(upsert).toBeDefined();
+      // The last bound argument is origin_msg_id; should be null when not provided.
+      expect(upsert!.bindings[upsert!.bindings.length - 1]).toBeNull();
+    });
+
     it('uses batchInChunks for large batches', async () => {
       const requests = Array.from({ length: 85 }, (_, i) => ({
         id: `r${i}`,
@@ -692,6 +733,36 @@ describe('Hono API', () => {
       expect(res.status).toBe(200);
       const body = await res.json() as { requests: Array<Record<string, unknown>> };
       expect(body.requests).toHaveLength(0);
+    });
+
+    it('maps origin_msg_id from D1 row to originMsgId on response', async () => {
+      mockDB._mockStatement.all.mockResolvedValueOnce({
+        results: [
+          {
+            id: 'r1', timestamp: '2024-01-01T00:00:00Z', donor: 'A', amount: 'R$10',
+            amount_val: 10, message: 'Trapper e Nurse', character: 'Trapper', type: 'killer',
+            done: 0, source: 'donation', needs_identification: 0,
+            origin_msg_id: 'twitch-msg-abc',
+          },
+          {
+            id: 'r2', timestamp: '2024-01-01T00:00:00Z', donor: 'A', amount: 'R$10',
+            amount_val: 10, message: 'Trapper e Nurse', character: 'Nurse', type: 'killer',
+            done: 0, source: 'donation', needs_identification: 0,
+            origin_msg_id: 'twitch-msg-abc',
+          },
+        ],
+      });
+
+      const token = await createTestToken({ login: 'testuser' });
+      const res = await app.request('/api/rooms/testuser/requests', {
+        headers: { Authorization: `Bearer ${token}` },
+      }, TEST_ENV);
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as { requests: Array<{ id: string; originMsgId?: string }> };
+      expect(body.requests).toHaveLength(2);
+      expect(body.requests[0].originMsgId).toBe('twitch-msg-abc');
+      expect(body.requests[1].originMsgId).toBe('twitch-msg-abc');
     });
   });
 

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -4,10 +4,9 @@ import app from './index';
 
 // Mock gemini
 vi.mock('./gemini', () => ({
-  extractCharacter: vi.fn().mockResolvedValue({
-    character: 'Meg Thomas',
-    type: 'survivor',
-  }),
+  extractCharacters: vi.fn().mockResolvedValue([
+    { character: 'Meg Thomas', type: 'survivor' },
+  ]),
 }));
 
 // Type definitions for API responses
@@ -387,8 +386,8 @@ describe('Hono API', () => {
     });
 
     it('returns 502 when Gemini fails', async () => {
-      const { extractCharacter } = await import('./gemini');
-      vi.mocked(extractCharacter).mockRejectedValueOnce(new Error('API rate limit'));
+      const { extractCharacters } = await import('./gemini');
+      vi.mocked(extractCharacters).mockRejectedValueOnce(new Error('API rate limit'));
 
       const token = await createTestToken();
 
@@ -404,6 +403,90 @@ describe('Hono API', () => {
       expect(res.status).toBe(502);
       const body = await res.json() as ErrorResponse;
       expect(body.error).toBe('llm_error');
+    });
+
+    it('returns a characters array (single result) and flat mirror', async () => {
+      const token = await createTestToken();
+
+      const res = await app.request('/api/extract-character', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ message: 'quero meg' }),
+      }, TEST_ENV);
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as {
+        characters: Array<{ character: string; type: string }>;
+        character?: string;
+        type?: string;
+      };
+      expect(Array.isArray(body.characters)).toBe(true);
+      expect(body.characters).toHaveLength(1);
+      expect(body.characters[0]).toMatchObject({ character: 'Meg Thomas', type: 'survivor' });
+      expect(body.character).toBe('Meg Thomas');
+      expect(body.type).toBe('survivor');
+    });
+
+    it('returns multiple characters when LLM yields more than one', async () => {
+      const { extractCharacters } = await import('./gemini');
+      vi.mocked(extractCharacters).mockResolvedValueOnce([
+        { character: 'Trapper', type: 'killer' },
+        { character: 'Trapper', type: 'killer' },
+        { character: 'Nurse', type: 'killer' },
+      ]);
+
+      const token = await createTestToken();
+      const res = await app.request('/api/extract-character', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ message: '2 de trapper e 1 de nurse', maxCount: 3 }),
+      }, TEST_ENV);
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as { characters: Array<{ character: string }>; character?: string };
+      expect(body.characters.map(c => c.character)).toEqual(['Trapper', 'Trapper', 'Nurse']);
+      expect(body.character).toBe('Trapper');
+    });
+
+    it('clamps maxCount to [1, 10]', async () => {
+      const { extractCharacters } = await import('./gemini');
+      vi.mocked(extractCharacters).mockResolvedValueOnce([{ character: 'Meg Thomas', type: 'survivor' }]);
+
+      const token = await createTestToken();
+      await app.request('/api/extract-character', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ message: 'meg', maxCount: 50 }),
+      }, TEST_ENV);
+
+      expect(vi.mocked(extractCharacters).mock.calls[0][2]).toBe(10);
+
+      vi.mocked(extractCharacters).mockResolvedValueOnce([{ character: 'Meg Thomas', type: 'survivor' }]);
+      await app.request('/api/extract-character', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ message: 'meg', maxCount: 0 }),
+      }, TEST_ENV);
+
+      expect(vi.mocked(extractCharacters).mock.calls[1][2]).toBe(1);
+    });
+
+    it('returns empty array and empty flat mirror when LLM yields nothing', async () => {
+      const { extractCharacters } = await import('./gemini');
+      vi.mocked(extractCharacters).mockResolvedValueOnce([]);
+
+      const token = await createTestToken();
+      const res = await app.request('/api/extract-character', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ message: 'oi tudo bem?' }),
+      }, TEST_ENV);
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as { characters: unknown[]; character?: string; type?: string };
+      expect(body.characters).toEqual([]);
+      expect(body.character).toBe('');
+      expect(body.type).toBe('none');
     });
   });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,7 +3,7 @@ import { cors } from "hono/cors";
 import { sign } from "hono/jwt";
 import { Twitch } from "arctic";
 import { verifyJwt, type JwtPayload } from "./jwt";
-import { extractCharacter } from "./gemini";
+import { extractCharacters } from "./gemini";
 import { getAppToken, fetchProfiles, fetchStreams, cacheProfiles, sendChatMessage, checkBotIsMod } from "./twitch";
 
 const BATCH_CHUNK_SIZE = 80;
@@ -196,11 +196,12 @@ api.use("*", async (c, next) => {
 // Twitch chat messages are capped at 500 characters
 const MAX_MESSAGE_LENGTH = 500;
 const DAILY_EXTRACT_LIMIT = 200;
+const MAX_DONATION_REQUESTS = 10;
 
 api.post("/extract-character", async (c) => {
   const user = c.get("jwtPayload");
   const clientVersion = c.req.header("X-Client-Version") || "unknown";
-  const body = await c.req.json<{ message: string }>();
+  const body = await c.req.json<{ message: string; maxCount?: number }>();
 
   if (!body.message || typeof body.message !== "string") {
     return c.json({ error: "invalid_input" }, 400);
@@ -210,7 +211,10 @@ api.post("/extract-character", async (c) => {
     return c.json({ error: "message_too_long", max: MAX_MESSAGE_LENGTH }, 400);
   }
 
-  // Per-user daily rate limit via KV
+  const requestedMax = typeof body.maxCount === "number" ? body.maxCount : 1;
+  const maxCount = Math.max(1, Math.min(MAX_DONATION_REQUESTS, Math.floor(requestedMax)));
+
+  // Per-user daily rate limit via KV (one extraction call = one unit, regardless of maxCount)
   const today = new Date().toISOString().slice(0, 10);
   const rateLimitKey = `ratelimit:extract:${user.sub}:${today}`;
   const currentCount = parseInt((await c.env.CACHE.get(rateLimitKey)) || "0", 10);
@@ -220,10 +224,10 @@ api.post("/extract-character", async (c) => {
     return c.json({ error: "daily_limit_exceeded", limit: DAILY_EXTRACT_LIMIT }, 429);
   }
 
-  console.log(`[v${clientVersion}] Extract request from ${user.login}: ${body.message.slice(0, 100)}`);
+  console.log(`[v${clientVersion}] Extract request from ${user.login} (maxCount=${maxCount}): ${body.message.slice(0, 100)}`);
 
   try {
-    const result = await extractCharacter(body.message, c.env.GEMINI_API_KEY);
+    const characters = await extractCharacters(body.message, c.env.GEMINI_API_KEY, maxCount);
 
     // Increment counter after successful extraction (TTL: 24h)
     const putPromise = c.env.CACHE.put(rateLimitKey, String(currentCount + 1), { expirationTtl: 86400 });
@@ -233,7 +237,14 @@ api.post("/extract-character", async (c) => {
       await putPromise;
     }
 
-    return c.json(result);
+    // Flat mirror for backward compatibility with older web clients.
+    const first = characters[0];
+    return c.json({
+      characters,
+      character: first?.character ?? "",
+      type: first?.type ?? "none",
+      matchedTerm: first?.matchedTerm,
+    });
   } catch (e: any) {
     console.error("Gemini error:", e.message);
     return c.json({ error: "llm_error", message: e.message }, 502);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -295,6 +295,7 @@ api.get("/rooms/:roomId/requests", async (c) => {
     subTier: r.sub_tier ?? undefined,
     needsIdentification: !!(r.needs_identification),
     matchedTerm: r.matched_term ?? undefined,
+    originMsgId: r.origin_msg_id ?? undefined,
   }));
 
   return c.json({ requests });
@@ -382,8 +383,8 @@ internal.put("/rooms/:roomId/requests", async (c) => {
     const position = typeof r._position === 'number' ? r._position : i;
     statements.push(
       c.env.DB.prepare(
-        `INSERT INTO requests (id, room_id, position, timestamp, donor, amount, amount_val, message, character, type, done, done_at, source, sub_tier, needs_identification, matched_term)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `INSERT INTO requests (id, room_id, position, timestamp, donor, amount, amount_val, message, character, type, done, done_at, source, sub_tier, needs_identification, matched_term, origin_msg_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT (room_id, id) DO UPDATE SET
            position = excluded.position,
            character = excluded.character,
@@ -391,7 +392,8 @@ internal.put("/rooms/:roomId/requests", async (c) => {
            done = excluded.done,
            done_at = excluded.done_at,
            needs_identification = excluded.needs_identification,
-           matched_term = excluded.matched_term`
+           matched_term = excluded.matched_term,
+           origin_msg_id = excluded.origin_msg_id`
       ).bind(
         r.id,
         roomId,
@@ -408,7 +410,8 @@ internal.put("/rooms/:roomId/requests", async (c) => {
         r.source,
         r.subTier ?? null,
         r.needsIdentification ? 1 : 0,
-        r.matchedTerm ?? null
+        r.matchedTerm ?? null,
+        r.originMsgId ?? null
       )
     );
   }
@@ -524,6 +527,7 @@ internal.get("/rooms/:roomId/requests", async (c) => {
     subTier: r.sub_tier ?? undefined,
     needsIdentification: !!(r.needs_identification),
     matchedTerm: r.matched_term ?? undefined,
+    originMsgId: r.origin_msg_id ?? undefined,
   }));
 
   return c.json({ requests });

--- a/apps/web/src/components/CharacterRequestCard.tsx
+++ b/apps/web/src/components/CharacterRequestCard.tsx
@@ -35,11 +35,13 @@ interface Props {
   exiting?: boolean;
   skipping?: boolean;
   entering?: boolean;
+  group?: { index: number; total: number };
 }
 
 export const CharacterRequestCard = memo(function CharacterRequestCard({
   request, position, onToggleDone,
-  isDragging, isDragOver, onDragStart, onDragOver, onDragEnd, readOnly = false, exiting = false, skipping = false, entering = false
+  isDragging, isDragOver, onDragStart, onDragOver, onDragEnd, readOnly = false, exiting = false, skipping = false, entering = false,
+  group,
 }: Props) {
   const { show: showContextMenu } = useContextMenu();
   const { t } = useTranslation();
@@ -146,7 +148,10 @@ export const CharacterRequestCard = memo(function CharacterRequestCard({
             {isValidating && <span className="validating-dot" title={t('card.validatingAI')} />}
           </div>
           <div className="request-card-body">
-            <span className="donor-name">{r.donor}</span>
+            <span className="donor-name">
+              {r.donor}
+              {group && <span className="donation-group-chip" title="Pedidos da mesma doação">{group.index}/{group.total}</span>}
+            </span>
             {matchedTerm ? highlightTerm(r.message, matchedTerm) : r.message}
           </div>
         </div>

--- a/apps/web/src/components/CharacterRequestList.tsx
+++ b/apps/web/src/components/CharacterRequestList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { identifyCharacter } from '../services';
 import { CharacterRequestCard } from './CharacterRequestCard';
 import { ContextMenu } from './ContextMenu';
@@ -14,6 +14,22 @@ export function CharacterRequestList() {
   const [draggedId, setDraggedId] = useState<number | null>(null);
   const [dragOverId, setDragOverId] = useState<number | null>(null);
   const readOnly = !canControlConnection;
+
+  const groupMap = useMemo(() => {
+    const groups = new Map<string, number[]>();
+    for (const r of requests) {
+      if (!r.originMsgId) continue;
+      const arr = groups.get(r.originMsgId) ?? [];
+      arr.push(r.id);
+      groups.set(r.originMsgId, arr);
+    }
+    const out = new Map<number, { index: number; total: number }>();
+    for (const ids of groups.values()) {
+      if (ids.length <= 1) continue;
+      ids.forEach((id, i) => out.set(id, { index: i + 1, total: ids.length }));
+    }
+    return out;
+  }, [requests]);
 
   // Track done/skipped items exiting so they stay in the DOM for the animation
   const [exitingIds, setExitingIds] = useState<Set<number>>(new Set());
@@ -191,6 +207,7 @@ export function CharacterRequestList() {
                 exiting={exitingIds.has(r.id)}
                 skipping={skippingIds.has(r.id)}
                 entering={enteringIds.has(r.id)}
+                group={groupMap.get(r.id)}
               />
             );
           });

--- a/apps/web/src/data/changelog.ts
+++ b/apps/web/src/data/changelog.ts
@@ -30,4 +30,9 @@ export const changelog: ChangelogEntry[] = [
     titleKey: 'whatsNew.chatConfirmationsTitle',
     descriptionKey: 'whatsNew.chatConfirmations',
   },
+  {
+    id: 'whats-new-multi-request-donations',
+    titleKey: 'whatsNew.multiRequestDonationsTitle',
+    descriptionKey: 'whatsNew.multiRequestDonations',
+  },
 ];

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -214,6 +214,8 @@ const en: TranslationKeys = {
   'whatsNew.title': "What's new",
   'whatsNew.langToggle': 'You can now switch between English and Portuguese in the footer.',
   'whatsNew.multiDonateBots': 'StreamElements (GGPix, and others) is now supported for donations, in addition to LivePix.',
+  'whatsNew.multiRequestDonationsTitle': '✨ New: multiple requests per donation',
+  'whatsNew.multiRequestDonations': 'Donations above the minimum can now contain multiple requests in one message — e.g. R$30 with R$10 minimum becomes up to 3 characters, including quantifiers like "2 de trapper".',
   'whatsNew.chatConfirmationsTitle': '✨ New: confirmations in chat',
   'whatsNew.chatConfirmations': 'The @FilaDBD bot can now confirm in chat whenever a request lands in the queue. Enable it in the sources panel.',
 

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -212,6 +212,8 @@ const ptBR = {
   'whatsNew.title': 'Novidade',
   'whatsNew.langToggle': 'Agora você pode alternar entre Português e Inglês no rodapé.',
   'whatsNew.multiDonateBots': 'StreamElements (GGPix, entre outros) agora é suportado para donates, além do LivePix.',
+  'whatsNew.multiRequestDonationsTitle': '✨ Novidade: vários pedidos por donate',
+  'whatsNew.multiRequestDonations': 'Donates acima do mínimo agora podem conter vários pedidos numa mesma mensagem — ex.: R$30 com mínimo R$10 vira até 3 personagens, incluindo quantificadores como "2 de trapper".',
   'whatsNew.chatConfirmationsTitle': '✨ Novidade: confirmações no chat',
   'whatsNew.chatConfirmations': 'O bot @FilaDBD agora pode confirmar no chat quando um pedido entra na fila. Ative  no painel de fontes.',
 

--- a/apps/web/src/services/donation.test.ts
+++ b/apps/web/src/services/donation.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { computeEntitlement, buildDonationRequests, MAX_DONATION_REQUESTS } from './donation';
+
+describe('computeEntitlement', () => {
+  it('returns 1 when amount equals minimum', () => {
+    expect(computeEntitlement(5, 5)).toBe(1);
+  });
+
+  it('returns floor(amount / min) for multiples', () => {
+    expect(computeEntitlement(10, 5)).toBe(2);
+    expect(computeEntitlement(14, 5)).toBe(2);
+    expect(computeEntitlement(15, 5)).toBe(3);
+  });
+
+  it('caps at MAX_DONATION_REQUESTS', () => {
+    expect(computeEntitlement(1000, 5)).toBe(MAX_DONATION_REQUESTS);
+  });
+
+  it('returns 1 when min is 0 or undefined (degenerate)', () => {
+    expect(computeEntitlement(10, 0)).toBe(1);
+  });
+
+  it('returns 1 when amount is below min (should not be called, but is safe)', () => {
+    expect(computeEntitlement(3, 5)).toBe(1);
+  });
+});
+
+describe('buildDonationRequests', () => {
+  const baseInput = {
+    donor: 'Donor',
+    amount: 'R$10',
+    amountVal: 10,
+    message: 'Trapper e Nurse',
+    twitchMsgId: 'twitch-abc',
+    timestampMs: 1_700_000_000_000,
+  };
+
+  it('builds one request per identified character with shared originMsgId', () => {
+    const out = buildDonationRequests({
+      ...baseInput,
+      identified: [
+        { character: 'Trapper', type: 'killer', matchedTerm: 'Trapper' },
+        { character: 'Nurse', type: 'killer', matchedTerm: 'Nurse' },
+      ],
+    });
+
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({
+      donor: 'Donor', amount: 'R$10', amountVal: 10, message: 'Trapper e Nurse',
+      character: 'Trapper', type: 'killer', source: 'donation',
+      needsIdentification: false, matchedTerm: 'Trapper',
+      originMsgId: 'twitch-abc',
+    });
+    expect(out[1].character).toBe('Nurse');
+    expect(out[0].originMsgId).toBe(out[1].originMsgId);
+    expect(out[0].id).not.toBe(out[1].id);
+  });
+
+  it('preserves duplicate characters in order', () => {
+    const out = buildDonationRequests({
+      ...baseInput,
+      message: '2 de trapper e 1 de nurse',
+      identified: [
+        { character: 'Trapper', type: 'killer' },
+        { character: 'Trapper', type: 'killer' },
+        { character: 'Nurse', type: 'killer' },
+      ],
+    });
+    expect(out.map(r => r.character)).toEqual(['Trapper', 'Trapper', 'Nurse']);
+    expect(new Set(out.map(r => r.id)).size).toBe(3);
+  });
+
+  it('returns a single "needs identification" request when identified is empty', () => {
+    const out = buildDonationRequests({ ...baseInput, identified: [] });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      character: 'Identificando...',
+      type: 'unknown',
+      needsIdentification: true,
+      originMsgId: 'twitch-abc',
+      message: 'Trapper e Nurse',
+    });
+  });
+
+  it('falls back to synthetic originMsgId when Twitch id is missing', () => {
+    const out = buildDonationRequests({ ...baseInput, twitchMsgId: undefined, identified: [
+      { character: 'Trapper', type: 'killer' },
+      { character: 'Nurse', type: 'killer' },
+    ] });
+    expect(out[0].originMsgId).toBeTruthy();
+    expect(out[0].originMsgId).toBe(out[1].originMsgId);
+    expect(out[0].originMsgId).toContain('Donor');
+  });
+});

--- a/apps/web/src/services/donation.ts
+++ b/apps/web/src/services/donation.ts
@@ -1,0 +1,84 @@
+import type { Request } from '../types';
+
+export const MAX_DONATION_REQUESTS = 10;
+
+export function computeEntitlement(amountVal: number, minDonation: number): number {
+  if (!minDonation || minDonation <= 0) return 1;
+  const n = Math.floor(amountVal / minDonation);
+  if (n < 1) return 1;
+  return Math.min(MAX_DONATION_REQUESTS, n);
+}
+
+interface BuildInput {
+  donor: string;
+  amount: string;
+  amountVal: number;
+  message: string;
+  twitchMsgId: string | undefined;
+  timestampMs: number;
+  identified: Array<{
+    character: string;
+    type: 'survivor' | 'killer' | 'unknown' | 'none' | string;
+    matchedTerm?: string;
+  }>;
+}
+
+function hashToInt(source: string): number {
+  let hash = 0;
+  for (let i = 0; i < source.length; i++) {
+    const char = source.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash;
+  }
+  return Math.abs(hash);
+}
+
+function makeId(twitchMsgId: string | undefined, fallback: string, index: number): number {
+  // No time-prefix here: at minute-precision * 1e9 the magnitude (~2.8e19) is past
+  // Number.MAX_SAFE_INTEGER and small hash differences (e.g. ":0" vs ":1") get rounded
+  // to the same float, producing colliding IDs. Hash alone gives 31 bits of uniqueness
+  // across the small set of segments, and the `position` column drives ordering.
+  const source = twitchMsgId ? `${twitchMsgId}:${index}` : `${fallback}:${index}`;
+  return hashToInt(source);
+}
+
+export function buildDonationRequests(input: BuildInput): Request[] {
+  const { donor, amount, amountVal, message, twitchMsgId, timestampMs, identified } = input;
+  const originMsgId = twitchMsgId ?? `synthetic:${donor}:${amount}:${timestampMs}`;
+  const timestamp = new Date(timestampMs);
+
+  if (identified.length === 0) {
+    const fallback = `donation:${donor}:${amount}:${message}`;
+    return [{
+      id: makeId(twitchMsgId, fallback, 0),
+      timestamp,
+      donor,
+      amount,
+      amountVal,
+      message,
+      character: 'Identificando...',
+      type: 'unknown',
+      source: 'donation',
+      needsIdentification: true,
+      originMsgId,
+    }];
+  }
+
+  return identified.map((c, i) => {
+    const fallback = `donation:${donor}:${amount}:${message}:${i}`;
+    return {
+      id: makeId(twitchMsgId, fallback, i),
+      timestamp,
+      donor,
+      amount,
+      amountVal,
+      message,
+      character: c.character || '',
+      type: (c.type as Request['type']) || 'unknown',
+      source: 'donation',
+      needsIdentification: false,
+      matchedTerm: c.matchedTerm,
+      originMsgId,
+    };
+  });
+}

--- a/apps/web/src/services/index.ts
+++ b/apps/web/src/services/index.ts
@@ -1,5 +1,5 @@
 export { connect, disconnect, handleMessage, handleUserNotice } from './twitch';
-export { identifyCharacter, testExtraction } from './llm';
+export { identifyCharacter, testExtraction, identifyMultiple } from './llm';
 export { loadAndReplayVOD, cancelVODReplay, recoverMissedRequests, fetchCurrentVodId } from './vod';
 export type { VODConfig, VODCallbacks, RecoveryConfig, RecoveryResult, RecoveryCallbacks } from './vod';
 export { tryLocalMatch, getKillerPortrait, CHARACTERS, DEFAULT_CHARACTERS } from '../data/characters';

--- a/apps/web/src/services/llm.ts
+++ b/apps/web/src/services/llm.ts
@@ -6,14 +6,15 @@ const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8787';
 
 declare const __APP_VERSION__: string;
 
+type ExtractedCharacter = { character: string; type: string; matchedTerm?: string };
+
 async function callAPI(
   message: string,
+  maxCount: number,
   onError?: (msg: string) => void
-): Promise<{ character: string; type: string; matchedTerm?: string }> {
+): Promise<ExtractedCharacter[]> {
   const token = await useAuth.getState().getAccessToken();
-  if (!token) {
-    return { character: '', type: 'none' };
-  }
+  if (!token) return [];
 
   try {
     const res = await fetch(`${API_URL}/api/extract-character`, {
@@ -23,25 +24,36 @@ async function callAPI(
         Authorization: `Bearer ${token}`,
         'X-Client-Version': __APP_VERSION__,
       },
-      body: JSON.stringify({ message }),
+      body: JSON.stringify({ message, maxCount }),
     });
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      const errorCode = (err as any).error;
+      const errorCode = (err as { error?: string }).error;
       if (errorCode === 'daily_limit_exceeded') {
         onError?.('Limite diário de identificações atingido');
-        return { character: '', type: 'none' };
+        return [];
       }
-      const msg = (err as any).message || errorCode || `HTTP ${res.status}`;
+      const msg = (err as { message?: string }).message || errorCode || `HTTP ${res.status}`;
       onError?.(msg);
-      return { character: 'Erro na API', type: 'unknown' };
+      return [{ character: 'Erro na API', type: 'unknown' }];
     }
 
-    return await res.json();
-  } catch (e: any) {
-    onError?.(e.message || 'Erro de rede');
-    return { character: 'Erro', type: 'unknown' };
+    const body = await res.json() as {
+      characters?: ExtractedCharacter[];
+      character?: string;
+      type?: string;
+      matchedTerm?: string;
+    };
+    if (Array.isArray(body.characters)) return body.characters;
+    if (body.character || body.type) {
+      return [{ character: body.character ?? '', type: body.type ?? 'none', matchedTerm: body.matchedTerm }];
+    }
+    return [];
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Erro de rede';
+    onError?.(msg);
+    return [{ character: 'Erro', type: 'unknown' }];
   }
 }
 
@@ -55,7 +67,8 @@ export async function identifyCharacter(
 
   if (local) {
     if (local.ambiguous && isAuthenticated && onLLMUpdate) {
-      callAPI(request.message, onError).then(llmResult => {
+      callAPI(request.message, 1, onError).then(arr => {
+        const llmResult = arr[0] ?? { character: '', type: 'none' };
         if (llmResult.type !== 'none' && llmResult.character) {
           onLLMUpdate({
             character: llmResult.character,
@@ -74,7 +87,8 @@ export async function identifyCharacter(
 
   if (!isAuthenticated) return { character: '', type: 'unknown' };
 
-  const result = await callAPI(request.message, onError);
+  const arr = await callAPI(request.message, 1, onError);
+  const result = arr[0] ?? { character: '', type: 'none' };
   const type = result.type || 'unknown';
   return {
     character: result.character || '',
@@ -95,7 +109,8 @@ export async function testExtraction(
 
   if (localResult) {
     if (localResult.ambiguous && isAuthenticated && onLLMUpdate) {
-      callAPI(input, onError).then(llmResult => {
+      callAPI(input, 1, onError).then(arr => {
+        const llmResult = arr[0] ?? { character: '', type: 'none' };
         if (llmResult.type !== 'none' && llmResult.character) {
           onLLMUpdate({
             character: llmResult.character,
@@ -111,10 +126,26 @@ export async function testExtraction(
     return { character: '', type: 'unknown', isLocal: false };
   }
 
-  const llm = await callAPI(input, onError);
+  const arr = await callAPI(input, 1, onError);
+  const llm = arr[0] ?? { character: '', type: 'none' };
   return {
     character: llm.character || '',
     type: (llm.type as 'killer' | 'survivor' | 'unknown') || 'unknown',
     isLocal: false
   };
+}
+
+export async function identifyMultiple(
+  message: string,
+  maxCount: number,
+  onError?: (msg: string) => void
+): Promise<Array<{ character: string; type: 'survivor' | 'killer' | 'unknown' | 'none'; matchedTerm?: string }>> {
+  const isAuthenticated = useAuth.getState().isAuthenticated;
+  if (!isAuthenticated) return [];
+  const arr = await callAPI(message, maxCount, onError);
+  return arr.map(c => ({
+    character: c.character ?? '',
+    type: (c.type ?? 'unknown') as 'survivor' | 'killer' | 'unknown' | 'none',
+    matchedTerm: c.matchedTerm,
+  }));
 }

--- a/apps/web/src/services/twitch.ts
+++ b/apps/web/src/services/twitch.ts
@@ -1,8 +1,10 @@
 import { tryLocalMatch } from '../data/characters';
 import { parseAmount, parseDonationMessage, isDonateBot } from '../utils/helpers';
-import { useSettings } from '../store';
+import { useSettings, useAuth } from '../store';
 import type { Request } from '../types';
 import type { ChannelStores } from '../store/channel';
+import { computeEntitlement, buildDonationRequests } from './donation';
+import { identifyMultiple } from './llm';
 
 export { DONATE_BOT_NAMES, isDonateBot } from '../utils/helpers';
 
@@ -255,26 +257,50 @@ export function handleMessage(raw: string) {
   const amountVal = parseAmount(parsed.amount);
   if (amountVal < minDonation) return;
 
-  const local = tryLocalMatch(parsed.message);
-
   // Use Twitch message ID for deterministic deduplication across tabs
   const twitchMsgId = tags['id'];
-  const fallbackContent = `donation:${parsed.donor}:${parsed.amount}:${parsed.message}`;
+  const entitlement = computeEntitlement(amountVal, minDonation);
+  const isAuthenticated = useAuth.getState().isAuthenticated;
+  const timestampMs = Date.now();
 
-  const request: Request = {
-    id: generateRequestId(twitchMsgId, fallbackContent),
-    timestamp: new Date(),
-    donor: parsed.donor,
-    amount: parsed.amount,
-    amountVal,
-    message: parsed.message,
-    character: local?.character || 'Identificando...',
-    type: local?.type || 'unknown',
-    source: 'donation',
-    needsIdentification: !local,
-    matchedTerm: local?.matchedTerm
-  };
-  addRequest(request);
+  if (entitlement === 1 || !isAuthenticated) {
+    // Single-request path (unchanged behavior, now with originMsgId).
+    // When un-authenticated for entitlement > 1, we cannot reliably split,
+    // so fall back to a single request — same UX as un-auth donations today.
+    const local = tryLocalMatch(parsed.message);
+    const fallbackContent = `donation:${parsed.donor}:${parsed.amount}:${parsed.message}`;
+    const request: Request = {
+      id: generateRequestId(twitchMsgId, fallbackContent),
+      timestamp: new Date(timestampMs),
+      donor: parsed.donor,
+      amount: parsed.amount,
+      amountVal,
+      message: parsed.message,
+      character: local?.character || 'Identificando...',
+      type: local?.type || 'unknown',
+      source: 'donation',
+      needsIdentification: !local,
+      matchedTerm: local?.matchedTerm,
+      originMsgId: twitchMsgId || `synthetic:${parsed.donor}:${parsed.amount}:${timestampMs}`,
+    };
+    addRequest(request);
+    return;
+  }
+
+  // Multi-request donation: always go through the LLM for accurate parsing
+  // (quantifiers like "2 de X", mixed natural language).
+  identifyMultiple(parsed.message, entitlement).then(characters => {
+    const built = buildDonationRequests({
+      donor: parsed.donor,
+      amount: parsed.amount,
+      amountVal,
+      message: parsed.message,
+      twitchMsgId,
+      timestampMs,
+      identified: characters,
+    });
+    for (const r of built) addRequest(r);
+  });
 }
 
 // Debug helpers exposed to window for DevTools testing

--- a/apps/web/src/styles/requests.css
+++ b/apps/web/src/styles/requests.css
@@ -199,6 +199,19 @@
   margin-right: 0.4em;
 }
 
+.donation-group-chip {
+  display: inline-block;
+  margin-left: 0.4em;
+  padding: 0 0.45em;
+  font-size: 0.75em;
+  font-weight: 600;
+  line-height: 1.5;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-muted, rgba(255, 255, 255, 0.6));
+  vertical-align: baseline;
+}
+
 .matched-term {
   background: none;
   color: inherit;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -25,6 +25,7 @@ export interface Request {
   needsIdentification?: boolean;
   validating?: boolean;
   matchedTerm?: string;
+  originMsgId?: string;
 }
 
 export type CharacterRequest = Request;


### PR DESCRIPTION
Lets a single donation that meets `N × minimum` produce up to `N` character requests parsed from the same message by the LLM — including natural-language quantifiers like *"oie, joga 2 de trapper e 1 de nurse por favor"* → 3 requests.

## What changed

- **API:** `/api/extract-character` accepts an optional `maxCount` (default 1, clamped to `[1, 10]`) and returns `{ characters: [...] }` plus a flat-field mirror for rolling-deploy compatibility with older clients.
- **Gemini prompt:** rewritten around the user's *command/intent* rather than a pattern list. Numeric quantifiers attach to the name they directly modify; character names mentioned only as context (current/past killer, comparisons, complaints) are excluded.
- **Donation flow** (`apps/web/src/services/twitch.ts`): when `entitlement > 1`, calls `identifyMultiple(message, entitlement)` once and creates one request per returned character. Un-authenticated and `entitlement === 1` paths preserve today's behavior exactly.
- **Grouping:** new optional `originMsgId` on `Request` (D1 migration `0006_add_origin_msg_id.sql`) ties derived requests to the source donation. UI derives an `N/M` chip per card by grouping the in-memory list on `originMsgId`.
- **Cap:** `MAX_DONATION_REQUESTS = 10` (server- and client-side).

## Release impact

- **Existing data:** untouched. Old rows have `origin_msg_id` NULL → no chip → unchanged appearance.
- **Migration:** `wrangler d1 migrations apply fila-dbd --remote --env production` before deploying the new Worker.
- **Rolling-deploy safe:** flat-field response mirror lets old clients keep working; `originMsgId` is optional everywhere.
- **No user action:** no cache clear, re-auth, or reconfiguration needed.

## Tests

- **Unit:** 130 API + 75 web = **205 passing** (typecheck + lint clean).
- **New API tests:** `maxCount` clamping, `characters[]` array shape, flat-field mirror, `origin_msg_id` persistence + round-trip mapping.
- **New web tests:** `computeEntitlement` (cap, degenerate inputs), `buildDonationRequests` (shared `originMsgId`, distinct deterministic IDs, duplicate preservation, fallback when un-identified).
- **Live LLM evals** (new): 34 parametrized scenarios in `apps/api/src/gemini.eval.test.ts`, sampled and anonymized from real `@mandymess` donations. Skipped by default (CI safe); run on demand via `cd apps/api && bun run test:eval` with `GEMINI_API_KEY` set. **Stability: 34/34 across 5 consecutive runs** (parallelized with `describe.concurrent`, ~7s total).

## Test plan for review

- [ ] `bun run typecheck` clean
- [ ] `bun run test` — 205 passing
- [ ] D1 migration applies cleanly locally (`cd apps/api && bunx wrangler d1 migrations apply fila-dbd --local`)
- [ ] (Optional) `bun run test:eval` for live LLM evals
- [ ] Smoke: a real 2× donation in dev produces 2 requests with a `1/2` and `2/2` chip