### PR TITLE
perf/fix(web): optimistic queue mutations & exit UX (3/4)

### DIFF
--- a/apps/api/src/party.ts
+++ b/apps/api/src/party.ts
@@ -294,7 +294,9 @@ export default class PartyServer implements Party.Server {
         }
         const pendingCount = this.requests.filter(r => !r.done).length;
         if (pendingCount >= MAX_PENDING_REQUESTS) {
-          this.sendError('pending_cap', `Fila cheia (${MAX_PENDING_REQUESTS}). Marque pedidos como feitos para liberar espaço.`);
+          // Include the rejected id so the client can roll back its optimistic insert
+          // (the reject path intentionally does not echo the add back).
+          this.sendError('pending_cap', `Fila cheia (${MAX_PENDING_REQUESTS}). Marque pedidos como feitos para liberar espaço.`, msg.request.id);
           console.warn(`${this.tag} ${user}: add-request #${msg.request.id} rejected (pending cap ${MAX_PENDING_REQUESTS})`);
           break;
         }
@@ -553,8 +555,8 @@ export default class PartyServer implements Party.Server {
     }
   }
 
-  private sendError(code: string, message: string) {
-    this.sendToOwner({ type: 'server-error', code, message });
+  private sendError(code: string, message: string, id?: number) {
+    this.sendToOwner({ type: 'server-error', code, message, id });
     console.error(`${this.tag} Error sent to owner: [${code}] ${message}`);
   }
 

--- a/apps/web/src/components/CharacterRequestList.tsx
+++ b/apps/web/src/components/CharacterRequestList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { identifyCharacter } from '../services';
 import { eligibleExtras } from '../services/extras';
 import { CharacterRequestCard } from './CharacterRequestCard';
@@ -42,7 +42,10 @@ export function CharacterRequestList() {
   const prevDoneIds = useRef<Set<number>>(new Set());
   const prevNoneIds = useRef<Set<number>>(new Set());
   const prevRequestIds = useRef<Set<number>>(new Set());
-  useEffect(() => {
+  // useLayoutEffect (not useEffect) so the exiting id is registered before paint.
+  // Otherwise the done item — already excluded from `filtered` — gets dropped from
+  // the DOM for one painted frame, then re-added to animate out (a visible shake).
+  useLayoutEffect(() => {
     const currentDone = new Set(requests.filter(r => r.done).map(r => r.id));
     // Only animate items that transitioned to done, not items that arrived as done from sync
     const newlyDone = [...currentDone].filter(id => !prevDoneIds.current.has(id) && prevRequestIds.current.has(id));
@@ -59,7 +62,9 @@ export function CharacterRequestList() {
     return () => clearTimeout(timer);
   }, [requests]);
 
-  useEffect(() => {
+  // useLayoutEffect for the same reason as the done effect above: register the
+  // skipping id before paint so the item never blinks out of the DOM.
+  useLayoutEffect(() => {
     const currentNone = new Set(requests.filter(r => r.type === 'none').map(r => r.id));
     // Only animate items that transitioned to 'none', not items that arrived as 'none' from sync
     const newlyNone = [...currentNone].filter(id => !prevNoneIds.current.has(id) && prevRequestIds.current.has(id));

--- a/apps/web/src/components/CharacterRequestList.tsx
+++ b/apps/web/src/components/CharacterRequestList.tsx
@@ -229,6 +229,8 @@ export function CharacterRequestList() {
           let activeIndex = 0;
           return filtered.map((r) => {
             const position = r.done ? undefined : ++activeIndex;
+            const exiting = exitingIds.has(r.id);
+            const skipping = skippingIds.has(r.id);
             return (
               <CharacterRequestCard
                 key={r.id}
@@ -241,9 +243,11 @@ export function CharacterRequestList() {
                 onDragOver={handleDragOver}
                 onDragEnd={handleDragEnd}
                 readOnly={readOnly}
-                exiting={exitingIds.has(r.id)}
-                skipping={skippingIds.has(r.id)}
-                entering={enteringIds.has(r.id)}
+                exiting={exiting}
+                skipping={skipping}
+                // Never let a just-arrived card play the enter animation while it's
+                // also exiting/skipping — the two animations fight and ghost.
+                entering={enteringIds.has(r.id) && !exiting && !skipping}
                 group={groupMap.get(r.id)}
               />
             );

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -248,6 +248,8 @@ const en: TranslationKeys = {
   'toast.reactivated': '{count} reactivated',
   'toast.reactivated_plural': '{count} reactivated',
   'toast.noConnection': 'No server connection. Try again.',
+  'toast.queueFull': 'Queue full ({max})',
+  'toast.queueFullDesc': 'Mark requests as done to free up space.',
   'toast.error': 'Error',
   'toast.linkCopied': 'Link copied to clipboard',
   'toast.sourcesUpdated': 'Queue settings updated',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -246,6 +246,8 @@ const ptBR = {
   'toast.reactivated': '{count} reativado',
   'toast.reactivated_plural': '{count} reativados',
   'toast.noConnection': 'Sem conexão com o servidor. Tente novamente.',
+  'toast.queueFull': 'Fila cheia ({max})',
+  'toast.queueFullDesc': 'Marque pedidos como feitos para liberar espaço.',
   'toast.error': 'Erro',
   'toast.linkCopied': 'Link copiado',
   'toast.sourcesUpdated': 'Configurações da fila atualizadas',

--- a/apps/web/src/services/party.ts
+++ b/apps/web/src/services/party.ts
@@ -83,8 +83,8 @@ export function broadcastToggleDone(id: number, done: boolean): void {
   send({ type: 'toggle-done', id, done });
 }
 
-export function broadcastReorder(fromId: number, toId: number): void {
-  send({ type: 'reorder', fromId, toId });
+export function broadcastReorder(fromId: number, toId: number, opId?: string): void {
+  send({ type: 'reorder', fromId, toId, opId });
 }
 
 export function broadcastDelete(id: number): void {

--- a/apps/web/src/store/ChannelContext.tsx
+++ b/apps/web/src/store/ChannelContext.tsx
@@ -239,6 +239,8 @@ export function ChannelProvider({ channel, children }: ChannelProviderProps) {
         (msg) => {
           if (msg.type === 'server-error') {
             console.error(`[server-error] ${msg.code}: ${msg.message}`);
+            // Let the requests store roll back an optimistic add the server rejected.
+            handleRequestsMessage(msg);
             if (msg.code === 'version_mismatch') {
               disconnectParty();
               toast.warning(t('toast.newVersionAvailable'), {

--- a/apps/web/src/store/channel.test.ts
+++ b/apps/web/src/store/channel.test.ts
@@ -180,7 +180,7 @@ describe('channel stores', () => {
   });
 
   describe('RequestsStore operations', () => {
-    it('add() broadcasts without updating local state', () => {
+    it('add() optimistically inserts locally and broadcasts', () => {
       const stores = createRoomStores('testchannel');
       stores.useChannelInfo.getState().setPartyConnectionState('connected');
 
@@ -188,7 +188,8 @@ describe('channel stores', () => {
       stores.useRequests.getState().add(request);
 
       expect(party.broadcastAdd).toHaveBeenCalledWith(request);
-      expect(stores.useRequests.getState().requests).toHaveLength(0);
+      expect(stores.useRequests.getState().requests).toHaveLength(1);
+      expect(stores.useRequests.getState().requests[0].id).toBe(request.id);
     });
 
     it('update() broadcasts without updating local state', () => {
@@ -215,6 +216,8 @@ describe('channel stores', () => {
       stores.useRequests.getState().toggleDone(456);
 
       expect(party.broadcastToggleDone).toHaveBeenCalledWith(456, true);
+      // Optimistic: flipped locally before any server echo.
+      expect(stores.useRequests.getState().requests.find(r => r.id === 456)?.done).toBe(true);
     });
 
     it('deleteRequest() broadcasts without updating local state', () => {
@@ -226,13 +229,21 @@ describe('channel stores', () => {
       expect(party.broadcastDelete).toHaveBeenCalledWith(789);
     });
 
-    it('reorder() broadcasts without updating local state', () => {
+    it('reorder() optimistically moves locally and broadcasts', () => {
       const stores = createRoomStores('testchannel');
       stores.useChannelInfo.getState().setPartyConnectionState('connected');
+      stores.useRequests.getState().handlePartyMessage({
+        type: 'sync-full',
+        requests: [serialized({ id: 1 }), serialized({ id: 2 }), serialized({ id: 3 })],
+        sources: {} as any,
+        channel: {} as any,
+      });
 
-      stores.useRequests.getState().reorder(2, 1);
+      // Move #3 to the position of #1 → [3, 1, 2].
+      stores.useRequests.getState().reorder(3, 1);
 
-      expect(party.broadcastReorder).toHaveBeenCalledWith(2, 1);
+      expect(party.broadcastReorder).toHaveBeenCalledWith(3, 1);
+      expect(stores.useRequests.getState().requests.map(r => r.id)).toEqual([3, 1, 2]);
     });
 
     it('setAll() broadcasts without updating local state', () => {
@@ -277,6 +288,81 @@ describe('channel stores', () => {
       stores.useSources.getState().toggleSource('chat');
 
       expect(party.broadcastSources).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('optimistic mutation reconciliation', () => {
+    function connectedStore() {
+      const stores = createRoomStores('testchannel');
+      stores.useChannelInfo.getState().setPartyConnectionState('connected');
+      return stores;
+    }
+
+    function seed(stores: ReturnType<typeof createRoomStores>, ids: number[]) {
+      stores.useRequests.getState().handlePartyMessage({
+        type: 'sync-full',
+        requests: ids.map(id => serialized({ id })),
+        sources: {} as any,
+        channel: {} as any,
+      });
+    }
+
+    it('add echo does not duplicate an optimistically-added request', () => {
+      const stores = connectedStore();
+      stores.useRequests.getState().add(createTestRequest({ id: 55 }));
+      expect(stores.useRequests.getState().requests).toHaveLength(1);
+      // Server echoes the same add back.
+      stores.useRequests.getState().handlePartyMessage({ type: 'add-request', request: serialized({ id: 55 }) } as any);
+      expect(stores.useRequests.getState().requests).toHaveLength(1);
+    });
+
+    it('toggle-done echo is idempotent for our own optimistic toggle', () => {
+      const stores = connectedStore();
+      seed(stores, [7]);
+      stores.useRequests.getState().toggleDone(7); // optimistic → done true
+      const after = stores.useRequests.getState().requests.find(r => r.id === 7)!;
+      // Server echoes toggle-done done:true — must be a no-op (same object ref).
+      stores.useRequests.getState().handlePartyMessage({ type: 'toggle-done', id: 7, done: true, doneAt: new Date().toISOString() } as any);
+      const echoed = stores.useRequests.getState().requests.find(r => r.id === 7)!;
+      expect(echoed.done).toBe(true);
+      expect(echoed).toBe(after);
+    });
+
+    it("toggle-done echo from another client still applies", () => {
+      const stores = connectedStore();
+      seed(stores, [8]);
+      // No local optimistic toggle; an echo flips it done.
+      stores.useRequests.getState().handlePartyMessage({ type: 'toggle-done', id: 8, done: true } as any);
+      expect(stores.useRequests.getState().requests.find(r => r.id === 8)?.done).toBe(true);
+    });
+
+    it('reorder echo of our own optimistic move is suppressed (no double-move)', () => {
+      const stores = connectedStore();
+      seed(stores, [1, 2, 3]);
+      stores.useRequests.getState().reorder(3, 1); // optimistic → [3,1,2]
+      expect(stores.useRequests.getState().requests.map(r => r.id)).toEqual([3, 1, 2]);
+      // Server echoes the same reorder — must NOT move again.
+      stores.useRequests.getState().handlePartyMessage({ type: 'reorder', fromId: 3, toId: 1 } as any);
+      expect(stores.useRequests.getState().requests.map(r => r.id)).toEqual([3, 1, 2]);
+    });
+
+    it('reorder from another client (no pending) is applied', () => {
+      const stores = connectedStore();
+      seed(stores, [1, 2, 3]);
+      stores.useRequests.getState().handlePartyMessage({ type: 'reorder', fromId: 1, toId: 3 } as any);
+      expect(stores.useRequests.getState().requests.map(r => r.id)).toEqual([2, 3, 1]);
+    });
+
+    it('sync-full clears pending reorders so a later identical echo applies', () => {
+      const stores = connectedStore();
+      seed(stores, [1, 2, 3]);
+      stores.useRequests.getState().reorder(3, 1); // pending {3,1}
+      // A fresh sync-full resets order and must clear the pending suppression.
+      seed(stores, [1, 2, 3]);
+      expect(stores.useRequests.getState().requests.map(r => r.id)).toEqual([1, 2, 3]);
+      // This echo is now NOT ours → should apply.
+      stores.useRequests.getState().handlePartyMessage({ type: 'reorder', fromId: 3, toId: 1 } as any);
+      expect(stores.useRequests.getState().requests.map(r => r.id)).toEqual([3, 1, 2]);
     });
   });
 

--- a/apps/web/src/store/channel.test.ts
+++ b/apps/web/src/store/channel.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createRoomStores, createSourcesStore } from './channel';
+import { MAX_PENDING_REQUESTS } from '@dbd-utils/shared';
 import type { Request } from '../types';
 import type { SourcesSettings } from '../types';
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn(), message: vi.fn(), info: vi.fn() },
+}));
 
 // Mock the party service broadcasts
 vi.mock('../services/party', () => ({
@@ -242,7 +247,7 @@ describe('channel stores', () => {
       // Move #3 to the position of #1 → [3, 1, 2].
       stores.useRequests.getState().reorder(3, 1);
 
-      expect(party.broadcastReorder).toHaveBeenCalledWith(3, 1);
+      expect(party.broadcastReorder).toHaveBeenCalledWith(3, 1, expect.any(String));
       expect(stores.useRequests.getState().requests.map(r => r.id)).toEqual([3, 1, 2]);
     });
 
@@ -341,9 +346,22 @@ describe('channel stores', () => {
       seed(stores, [1, 2, 3]);
       stores.useRequests.getState().reorder(3, 1); // optimistic → [3,1,2]
       expect(stores.useRequests.getState().requests.map(r => r.id)).toEqual([3, 1, 2]);
-      // Server echoes the same reorder — must NOT move again.
-      stores.useRequests.getState().handlePartyMessage({ type: 'reorder', fromId: 3, toId: 1 } as any);
+      // The server echoes our reorder verbatim, including the opId we tagged it with.
+      const opId = vi.mocked(party.broadcastReorder).mock.calls[0][2];
+      expect(opId).toBeTruthy();
+      stores.useRequests.getState().handlePartyMessage({ type: 'reorder', fromId: 3, toId: 1, opId } as any);
       expect(stores.useRequests.getState().requests.map(r => r.id)).toEqual([3, 1, 2]);
+    });
+
+    it('a foreign reorder with the same coords as a pending one still applies (operation identity)', () => {
+      const stores = connectedStore();
+      seed(stores, [1, 2, 3]);
+      stores.useRequests.getState().reorder(3, 1); // optimistic → [3,1,2], tagged with our opId
+      // Another client independently performs the SAME move (3→pos of 1). It carries a
+      // DIFFERENT opId, so it must NOT be swallowed by our pending suppression.
+      stores.useRequests.getState().handlePartyMessage({ type: 'reorder', fromId: 3, toId: 1, opId: 'someone-else' } as any);
+      // Applied on top of [3,1,2]: move id 3 to position of id 1 → [1,3,2].
+      expect(stores.useRequests.getState().requests.map(r => r.id)).toEqual([1, 3, 2]);
     });
 
     it('reorder from another client (no pending) is applied', () => {
@@ -363,6 +381,65 @@ describe('channel stores', () => {
       // This echo is now NOT ours → should apply.
       stores.useRequests.getState().handlePartyMessage({ type: 'reorder', fromId: 3, toId: 1 } as any);
       expect(stores.useRequests.getState().requests.map(r => r.id)).toEqual([3, 1, 2]);
+    });
+  });
+
+  describe('optimistic add rejection (pending cap)', () => {
+    function connectedStore() {
+      const stores = createRoomStores('testchannel');
+      stores.useChannelInfo.getState().setPartyConnectionState('connected');
+      return stores;
+    }
+
+    it('add() does not insert or broadcast when the queue is at the pending cap', () => {
+      const stores = connectedStore();
+      // Fill the queue to the server-enforced pending cap.
+      stores.useRequests.getState().handlePartyMessage({
+        type: 'sync-full',
+        requests: Array.from({ length: MAX_PENDING_REQUESTS }, (_, i) => serialized({ id: i + 1 })),
+        sources: {} as any,
+        channel: {} as any,
+      });
+
+      stores.useRequests.getState().add(createTestRequest({ id: 9999 }));
+
+      expect(stores.useRequests.getState().requests).toHaveLength(MAX_PENDING_REQUESTS);
+      expect(stores.useRequests.getState().requests.some(r => r.id === 9999)).toBe(false);
+      expect(party.broadcastAdd).not.toHaveBeenCalled();
+    });
+
+    it('done requests do not count toward the pending cap', () => {
+      const stores = connectedStore();
+      stores.useRequests.getState().handlePartyMessage({
+        type: 'sync-full',
+        requests: Array.from({ length: MAX_PENDING_REQUESTS }, (_, i) => serialized({ id: i + 1, done: true })),
+        sources: {} as any,
+        channel: {} as any,
+      });
+
+      stores.useRequests.getState().add(createTestRequest({ id: 9999 }));
+
+      expect(stores.useRequests.getState().requests.some(r => r.id === 9999)).toBe(true);
+      expect(party.broadcastAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('a pending_cap server-error rolls back the matching optimistic add', () => {
+      const stores = connectedStore();
+      // Optimistic add succeeds locally (under cap), but the server rejects it
+      // (e.g. another tab filled the last slot first) and does NOT echo it back.
+      stores.useRequests.getState().add(createTestRequest({ id: 500 }));
+      expect(stores.useRequests.getState().requests.some(r => r.id === 500)).toBe(true);
+
+      stores.useRequests.getState().handlePartyMessage({ type: 'server-error', code: 'pending_cap', id: 500 } as any);
+
+      expect(stores.useRequests.getState().requests.some(r => r.id === 500)).toBe(false);
+    });
+
+    it('a server-error without an id leaves the queue untouched', () => {
+      const stores = connectedStore();
+      stores.useRequests.getState().add(createTestRequest({ id: 501 }));
+      stores.useRequests.getState().handlePartyMessage({ type: 'server-error', code: 'not_room_owner', message: 'x' } as any);
+      expect(stores.useRequests.getState().requests.some(r => r.id === 501)).toBe(true);
     });
   });
 

--- a/apps/web/src/store/channel.ts
+++ b/apps/web/src/store/channel.ts
@@ -5,6 +5,7 @@ import type { RoomExtras } from '@dbd-utils/shared';
 import type { ConnectionState, Request, SourcesEnabled, PartyMessage, ChannelStatus } from '../types';
 import { deserializeRequest, deserializeRequests } from '../types';
 import { loadCachedQueue, saveCachedQueue } from './queueCache';
+import { insertRequest, moveRequest, setRequestDone } from '../utils/requests';
 import { toast } from 'sonner';
 import { t } from '../i18n';
 import {
@@ -44,6 +45,14 @@ export function createRequestsStore(
   getSourcesState: () => SourcesStore,
   getContext: () => { partyConnected: boolean }
 ) {
+  // Reorders we applied optimistically and are still awaiting the server echo for.
+  // The server rebroadcasts reorder to *every* client including the sender, and a
+  // positional move isn't idempotent — re-applying our own echo would double-move.
+  // So we record each optimistic reorder and skip the matching echo (FIFO: one
+  // socket preserves send/echo order). Cleared on sync-full/set-all, which reset
+  // ordering wholesale.
+  const pendingReorders: { fromId: number; toId: number }[] = [];
+
   const useRequests = create<RequestsStore>()(
       (set, get) => ({
         // Hydrate from the local cache so the queue paints instantly on reload,
@@ -52,6 +61,10 @@ export function createRequestsStore(
 
         add: (req) => {
           if (!requireParty(getContext)) return;
+          // Optimistic: insert locally now, broadcast next. The server echoes
+          // add-request back, but the echo dedupes by id (no-op for us).
+          const { sortMode, priority } = getSourcesState();
+          set((s) => ({ requests: insertRequest(s.requests, req, sortMode, priority) }));
           broadcastAdd(req);
         },
 
@@ -64,7 +77,10 @@ export function createRequestsStore(
           if (!requireParty(getContext)) return;
           const req = get().requests.find(r => r.id === id);
           if (!req) return;
-          broadcastToggleDone(id, !req.done);
+          const done = !req.done;
+          // Optimistic: flip locally now; the toggle-done echo is idempotent.
+          set((s) => ({ requests: setRequestDone(s.requests, id, done) }));
+          broadcastToggleDone(id, done);
         },
 
         setAll: (requests) => {
@@ -74,6 +90,14 @@ export function createRequestsStore(
 
         reorder: (fromId, toId) => {
           if (!requireParty(getContext)) return;
+          // Optimistic: move locally now and remember it so the server echo of
+          // this same reorder is skipped (it would otherwise double-move).
+          const current = get().requests;
+          const next = moveRequest(current, fromId, toId);
+          if (next !== current) {
+            set({ requests: next });
+            pendingReorders.push({ fromId, toId });
+          }
           broadcastReorder(fromId, toId);
         },
 
@@ -85,30 +109,20 @@ export function createRequestsStore(
         handlePartyMessage: (msg) => {
           switch (msg.type) {
             case 'sync-full': {
+              // Authoritative full replace — ordering is reset, so drop any
+              // pending optimistic reorders awaiting an echo.
+              pendingReorders.length = 0;
               set({ requests: deserializeRequests(msg.requests) });
               break;
             }
             case 'add-request': {
               const req = deserializeRequest(msg.request);
+              const { sortMode, priority } = getSourcesState();
+              // insertRequest dedupes by id, so our own optimistic add is a no-op
+              // here (returns the same array → no re-render).
               set((s) => {
-                if (s.requests.some(r => r.id === req.id)) return s;
-                const { sortMode, priority } = getSourcesState();
-                if (sortMode === 'fifo') {
-                  return { requests: [...s.requests, req] };
-                }
-                const requests = [...s.requests];
-                const reqPri = priority.indexOf(req.source);
-                let insertIdx = requests.length;
-                for (let i = 0; i < requests.length; i++) {
-                  if (requests[i].done) continue;
-                  const iPri = priority.indexOf(requests[i].source);
-                  if (iPri > reqPri || (iPri === reqPri && requests[i].timestamp > req.timestamp)) {
-                    insertIdx = i;
-                    break;
-                  }
-                }
-                requests.splice(insertIdx, 0, req);
-                return { requests };
+                const requests = insertRequest(s.requests, req, sortMode, priority);
+                return requests === s.requests ? s : { requests };
               });
               break;
             }
@@ -135,29 +149,37 @@ export function createRequestsStore(
             case 'ownership-denied':
               break;
             case 'toggle-done':
-              set((s) => ({
-                requests: s.requests.map((r) => (r.id === msg.id
-                  ? { ...r, done: msg.done, doneAt: msg.done ? (msg.doneAt ? new Date(msg.doneAt) : new Date()) : undefined }
-                  : r)),
-              }));
-              break;
-            case 'reorder':
               set((s) => {
-                const requests = [...s.requests];
-                const fromIdx = requests.findIndex(r => r.id === msg.fromId);
-                const toIdx = requests.findIndex(r => r.id === msg.toId);
-                if (fromIdx === -1 || toIdx === -1) return s;
-                const [moved] = requests.splice(fromIdx, 1);
-                requests.splice(toIdx, 0, moved);
-                return { requests };
+                // Idempotent: if already in the target state (our own optimistic
+                // toggle, echoed back), do nothing. Others' toggles still apply.
+                const existing = s.requests.find((r) => r.id === msg.id);
+                if (!existing || existing.done === msg.done) return s;
+                return {
+                  requests: setRequestDone(s.requests, msg.id, msg.done, msg.doneAt ? new Date(msg.doneAt) : undefined),
+                };
               });
               break;
+            case 'reorder': {
+              // Skip the echo of a reorder we already applied optimistically
+              // (would otherwise double-move); apply reorders from other clients.
+              const pending = pendingReorders[0];
+              if (pending && pending.fromId === msg.fromId && pending.toId === msg.toId) {
+                pendingReorders.shift();
+                break;
+              }
+              set((s) => {
+                const requests = moveRequest(s.requests, msg.fromId, msg.toId);
+                return requests === s.requests ? s : { requests };
+              });
+              break;
+            }
             case 'delete-request':
               set((s) => ({
                 requests: s.requests.filter((r) => r.id !== msg.id),
               }));
               break;
             case 'set-all':
+              pendingReorders.length = 0;
               set({ requests: deserializeRequests(msg.requests) });
               break;
           }

--- a/apps/web/src/store/channel.ts
+++ b/apps/web/src/store/channel.ts
@@ -46,9 +46,14 @@ export function createRequestsStore(
   getContext: () => { partyConnected: boolean }
 ) {
   // Optimistic reorders awaiting their server echo. The server echoes a reorder to
-  // every client and a positional move isn't idempotent, so we skip the matching
-  // echo (FIFO order) to avoid double-moving. Cleared on sync-full/set-all.
-  const pendingReorders: { fromId: number; toId: number }[] = [];
+  // every client and a positional move isn't idempotent, so we must skip the echo of
+  // our OWN move (it would double-move). Each optimistic reorder is tagged with a
+  // unique opId that the server forwards verbatim, so we match echoes by identity
+  // rather than by {fromId,toId} value — which can't tell our move apart from another
+  // client's identical move. Cleared on the authoritative sync-full/set-all.
+  const pendingReorderOpIds = new Set<string>();
+  const newOpId = (): string =>
+    globalThis.crypto?.randomUUID?.() ?? `r-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 
   const useRequests = create<RequestsStore>()(
       (set, get) => ({
@@ -58,6 +63,16 @@ export function createRequestsStore(
 
         add: (req) => {
           if (!requireParty(getContext)) return;
+          // Mirror the server's pending cap so we don't optimistically insert a request
+          // the server will reject (it rejects without echoing, which would otherwise
+          // leave a phantom row locally). The pending_cap server-error rolls back the
+          // rarer race where two clients fill the last slot at once.
+          if (get().requests.filter((r) => !r.done).length >= MAX_PENDING_REQUESTS) {
+            toast.error(t('toast.queueFull', { max: String(MAX_PENDING_REQUESTS) }), {
+              description: t('toast.queueFullDesc'),
+            });
+            return;
+          }
           // Optimistic: insert locally now, broadcast next. The server echoes
           // add-request back, but the echo dedupes by id (no-op for us).
           const { sortMode, priority } = getSourcesState();
@@ -87,15 +102,16 @@ export function createRequestsStore(
 
         reorder: (fromId, toId) => {
           if (!requireParty(getContext)) return;
-          // Optimistic: move locally now and remember it so the server echo of
+          // Optimistic: move locally now and remember its opId so the server echo of
           // this same reorder is skipped (it would otherwise double-move).
           const current = get().requests;
           const next = moveRequest(current, fromId, toId);
+          const opId = newOpId();
           if (next !== current) {
             set({ requests: next });
-            pendingReorders.push({ fromId, toId });
+            pendingReorderOpIds.add(opId);
           }
-          broadcastReorder(fromId, toId);
+          broadcastReorder(fromId, toId, opId);
         },
 
         deleteRequest: (id) => {
@@ -108,7 +124,7 @@ export function createRequestsStore(
             case 'sync-full': {
               // Authoritative full replace — ordering is reset, so drop any
               // pending optimistic reorders awaiting an echo.
-              pendingReorders.length = 0;
+              pendingReorderOpIds.clear();
               set({ requests: deserializeRequests(msg.requests) });
               break;
             }
@@ -157,11 +173,10 @@ export function createRequestsStore(
               });
               break;
             case 'reorder': {
-              // Skip the echo of a reorder we already applied optimistically
-              // (would otherwise double-move); apply reorders from other clients.
-              const pending = pendingReorders[0];
-              if (pending && pending.fromId === msg.fromId && pending.toId === msg.toId) {
-                pendingReorders.shift();
+              // Skip the echo of a reorder we already applied optimistically (matched by
+              // our own opId — would otherwise double-move); apply everyone else's.
+              if (msg.opId && pendingReorderOpIds.has(msg.opId)) {
+                pendingReorderOpIds.delete(msg.opId);
                 break;
               }
               set((s) => {
@@ -176,8 +191,18 @@ export function createRequestsStore(
               }));
               break;
             case 'set-all':
-              pendingReorders.length = 0;
+              pendingReorderOpIds.clear();
               set({ requests: deserializeRequests(msg.requests) });
+              break;
+            case 'server-error':
+              // The server rejects an over-cap add without echoing it, so roll back the
+              // optimistic insert it points at. Other errors carry no id and are no-ops here.
+              if (msg.code === 'pending_cap' && typeof msg.id === 'number') {
+                set((s) => {
+                  const requests = s.requests.filter((r) => r.id !== msg.id);
+                  return requests.length === s.requests.length ? s : { requests };
+                });
+              }
               break;
           }
         },

--- a/apps/web/src/store/channel.ts
+++ b/apps/web/src/store/channel.ts
@@ -45,12 +45,9 @@ export function createRequestsStore(
   getSourcesState: () => SourcesStore,
   getContext: () => { partyConnected: boolean }
 ) {
-  // Reorders we applied optimistically and are still awaiting the server echo for.
-  // The server rebroadcasts reorder to *every* client including the sender, and a
-  // positional move isn't idempotent — re-applying our own echo would double-move.
-  // So we record each optimistic reorder and skip the matching echo (FIFO: one
-  // socket preserves send/echo order). Cleared on sync-full/set-all, which reset
-  // ordering wholesale.
+  // Optimistic reorders awaiting their server echo. The server echoes a reorder to
+  // every client and a positional move isn't idempotent, so we skip the matching
+  // echo (FIFO order) to avoid double-moving. Cleared on sync-full/set-all.
   const pendingReorders: { fromId: number; toId: number }[] = [];
 
   const useRequests = create<RequestsStore>()(
@@ -188,8 +185,7 @@ export function createRequestsStore(
   );
 
   // Persist on every change so the next reload restores the latest queue. The
-  // authoritative sync-full / set-all replacements are what end up cached, so
-  // stale or server-deleted rows never survive a reconcile.
+  // authoritative sync-full/set-all replacements get cached, so stale rows don't survive.
   useRequests.subscribe((state) => saveCachedQueue(channel, state.requests));
 
   return useRequests;

--- a/apps/web/src/styles/requests.css
+++ b/apps/web/src/styles/requests.css
@@ -27,22 +27,37 @@
   text-align: right;
 }
 
+/* Exit = fade + slide (first ~40%), then collapse the card's box to 0 so the rows
+   below glide up smoothly instead of snapping shut when the card is removed at the
+   end of the timer. border-box keeps padding/border in the height, so they collapse
+   too; overflow:hidden clips the content during the collapse. The animation length
+   matches the removal timer (500ms done / 400ms skip) so the card is already fully
+   collapsed by the time it unmounts. */
 .request-card.deleting {
-  animation: deleteSlide 0.5s var(--ease-in) forwards;
+  /* Shorter than the 500ms removal timer so the collapse fully finishes (height 0)
+     before the card unmounts — otherwise the row snaps the remaining height shut. */
+  animation: deleteSlide 0.4s var(--ease-out) forwards;
   pointer-events: none;
+  overflow: hidden;
 }
 
 @keyframes deleteSlide {
-  to { opacity: 0; transform: translateX(-100%); }
+  0%   { opacity: 1; transform: translateX(0);     max-height: 300px; padding-top: var(--space-lg); padding-bottom: var(--space-lg); border-bottom-width: 1px; }
+  40%  { opacity: 0; transform: translateX(-100%); max-height: 300px; padding-top: var(--space-lg); padding-bottom: var(--space-lg); border-bottom-width: 1px; }
+  100% { opacity: 0; transform: translateX(-100%); max-height: 0;     padding-top: 0; padding-bottom: 0; border-bottom-width: 0; }
 }
 
 .request-card.skipping {
-  animation: skipSlide 0.4s var(--ease-in) forwards;
+  /* Shorter than the 400ms removal timer (see deleting above). */
+  animation: skipSlide 0.3s var(--ease-out) forwards;
   pointer-events: none;
+  overflow: hidden;
 }
 
 @keyframes skipSlide {
-  to { opacity: 0; transform: translateX(30px); }
+  0%   { opacity: 1; transform: translateX(0);    max-height: 300px; padding-top: var(--space-lg); padding-bottom: var(--space-lg); border-bottom-width: 1px; }
+  40%  { opacity: 0; transform: translateX(30px); max-height: 300px; padding-top: var(--space-lg); padding-bottom: var(--space-lg); border-bottom-width: 1px; }
+  100% { opacity: 0; transform: translateX(30px); max-height: 0;     padding-top: 0; padding-bottom: 0; border-bottom-width: 0; }
 }
 
 @keyframes requestEnter {

--- a/apps/web/src/styles/requests.css
+++ b/apps/web/src/styles/requests.css
@@ -27,24 +27,25 @@
   text-align: right;
 }
 
-/* Exit = fade + slide (first ~40%), then collapse the card's box to 0 so the rows
-   below glide up smoothly instead of snapping shut when the card is removed at the
-   end of the timer. border-box keeps padding/border in the height, so they collapse
-   too; overflow:hidden clips the content during the collapse. The animation length
-   matches the removal timer (500ms done / 400ms skip) so the card is already fully
-   collapsed by the time it unmounts. */
+/* Exit: done fades in place (first ~40%) then collapses; skip fades + slides then
+   collapses. Collapsing the card's box to 0 lets the rows below glide up smoothly
+   instead of snapping shut when the card is removed at the end of the timer.
+   border-box keeps padding/border in the height, so they collapse too;
+   overflow:hidden clips the content during the collapse. The animation length is
+   shorter than the removal timer (500ms done / 400ms skip) so the card is already
+   fully collapsed by the time it unmounts. */
 .request-card.deleting {
   /* Shorter than the 500ms removal timer so the collapse fully finishes (height 0)
      before the card unmounts — otherwise the row snaps the remaining height shut. */
-  animation: deleteSlide 0.4s var(--ease-out) forwards;
+  animation: deleteCollapse 0.4s var(--ease-out) forwards;
   pointer-events: none;
   overflow: hidden;
 }
 
-@keyframes deleteSlide {
-  0%   { opacity: 1; transform: translateX(0);     max-height: 300px; padding-top: var(--space-lg); padding-bottom: var(--space-lg); border-bottom-width: 1px; }
-  40%  { opacity: 0; transform: translateX(-100%); max-height: 300px; padding-top: var(--space-lg); padding-bottom: var(--space-lg); border-bottom-width: 1px; }
-  100% { opacity: 0; transform: translateX(-100%); max-height: 0;     padding-top: 0; padding-bottom: 0; border-bottom-width: 0; }
+@keyframes deleteCollapse {
+  0%   { opacity: 1; max-height: 300px; padding-top: var(--space-lg); padding-bottom: var(--space-lg); border-bottom-width: 1px; }
+  40%  { opacity: 0; max-height: 300px; padding-top: var(--space-lg); padding-bottom: var(--space-lg); border-bottom-width: 1px; }
+  100% { opacity: 0; max-height: 0;     padding-top: 0; padding-bottom: 0; border-bottom-width: 0; }
 }
 
 .request-card.skipping {

--- a/apps/web/src/utils/requests.ts
+++ b/apps/web/src/utils/requests.ts
@@ -33,3 +33,54 @@ export function mergeRequests(
     skipped: selected.length - newReqs.length,
   };
 }
+
+// ---- Pure queue ops, shared by optimistic actions and the PartyKit echo handlers ----
+//
+// Each returns the SAME array reference when nothing changes, so a zustand
+// `set(() => fn(...))` is a no-op (no re-render) for a duplicate/no-op echo.
+
+/** Insert a request at its sorted position. Dedupes by id (returns input unchanged). */
+export function insertRequest(
+  requests: Request[],
+  req: Request,
+  sortMode: SortMode,
+  priority: string[]
+): Request[] {
+  if (requests.some(r => r.id === req.id)) return requests;
+  if (sortMode === 'fifo') return [...requests, req];
+  const out = [...requests];
+  const reqPri = priority.indexOf(req.source);
+  let insertIdx = out.length;
+  for (let i = 0; i < out.length; i++) {
+    if (out[i].done) continue;
+    const iPri = priority.indexOf(out[i].source);
+    if (iPri > reqPri || (iPri === reqPri && out[i].timestamp > req.timestamp)) {
+      insertIdx = i;
+      break;
+    }
+  }
+  out.splice(insertIdx, 0, req);
+  return out;
+}
+
+/** Move the request `fromId` to the position of `toId`. No-op if either is missing. */
+export function moveRequest(requests: Request[], fromId: number, toId: number): Request[] {
+  const fromIdx = requests.findIndex(r => r.id === fromId);
+  const toIdx = requests.findIndex(r => r.id === toId);
+  if (fromIdx === -1 || toIdx === -1) return requests;
+  const out = [...requests];
+  const [moved] = out.splice(fromIdx, 1);
+  out.splice(toIdx, 0, moved);
+  return out;
+}
+
+/** Set a request's done state (and doneAt). No-op if the id is absent. */
+export function setRequestDone(requests: Request[], id: number, done: boolean, doneAt?: Date): Request[] {
+  let changed = false;
+  const out = requests.map(r => {
+    if (r.id !== id) return r;
+    changed = true;
+    return { ...r, done, doneAt: done ? (doneAt ?? new Date()) : undefined };
+  });
+  return changed ? out : requests;
+}

--- a/packages/shared/src/party.ts
+++ b/packages/shared/src/party.ts
@@ -49,7 +49,7 @@ export type PartyMessage =
   | { type: 'add-request'; request: SerializedRequest }
   | { type: 'update-request'; id: number; updates: Partial<SerializedRequest> }
   | { type: 'toggle-done'; id: number; done: boolean; doneAt?: string }
-  | { type: 'reorder'; fromId: number; toId: number }
+  | { type: 'reorder'; fromId: number; toId: number; opId?: string }
   | { type: 'delete-request'; id: number }
   | { type: 'set-all'; requests: SerializedRequest[] }
   | { type: 'update-sources'; sources: SourcesSettings }
@@ -59,7 +59,7 @@ export type PartyMessage =
   | { type: 'release-ownership' }
   | { type: 'ownership-granted' }
   | { type: 'ownership-denied'; currentOwner: string }
-  | { type: 'server-error'; code: string; message: string };
+  | { type: 'server-error'; code: string; message: string; id?: number };
 
 export function serializeRequest(req: Request): SerializedRequest {
   return {


### PR DESCRIPTION
**Stack 3 of 4** — base: \`split/2-instant-paint-cache\` (#25). Merge after #25.

Make queue mutations feel instant, with correctness guards for the multi-client cases.

- Optimistic \`add\` / \`toggleDone\` / \`reorder\` (apply locally, broadcast, dedupe the server echo)
- Match reorder echoes by a unique **opId** instead of \`{fromId,toId}\` value — so we skip *our own* move, not another client's identical move
- Mirror the server's pending cap on the client (toast instead of a phantom row); roll back the rarer race via a \`pending_cap\` server-error carrying the rejected id
- Smooth the done/skip exit (\`deleteCollapse\`: fade in place then collapse the box so rows glide up instead of snapping shut); stop the flicker

### Release impact
- \`reorder\` and \`server-error\` PartyKit messages gain optional \`opId\` / \`id\` fields. Both optional → old/new clients and servers stay compatible during rolling deploys.

Typechecks clean; \`store/channel.test.ts\` covers the opId echo-matching and pending-cap rollback. Review/merge in order: 1 → 2 → 3 → 4.