### PR TITLE
perf(web): skip the LLM on a whole-message local match (4/4)

### DIFF
--- a/apps/web/src/data/characters.test.ts
+++ b/apps/web/src/data/characters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { tryLocalMatch } from './characters';
+import { tryLocalMatch, isWholeMessageMatch } from './characters';
 
 describe('tryLocalMatch', () => {
   it('matches a single alias', () => {
@@ -19,5 +19,41 @@ describe('tryLocalMatch', () => {
     const result = tryLocalMatch('quero vecna');
     expect(result?.character).toBe('Lich');
     expect(result?.ambiguous).toBe(true);
+  });
+});
+
+describe('isWholeMessageMatch', () => {
+  const check = (message: string) => isWholeMessageMatch(tryLocalMatch(message), message);
+
+  it('is true when the message is exactly a character name', () => {
+    expect(check('Trapper')).toBe(true);
+  });
+
+  it('is true ignoring surrounding whitespace and case', () => {
+    expect(check('  trapper  ')).toBe(true);
+  });
+
+  it('is true for an alias that spans the whole message', () => {
+    expect(check('Caçador')).toBe(true);
+  });
+
+  it('is false when there is text beyond the character name', () => {
+    expect(check('Trapper com mori')).toBe(false);
+    expect(check('quero Trapper')).toBe(false);
+  });
+
+  it('is false when the whole message is an ambiguous match', () => {
+    // "vecna" is both Lich and The First — whole-message but ambiguous, so the LLM
+    // must still disambiguate.
+    expect(tryLocalMatch('vecna')?.ambiguous).toBe(true);
+    expect(check('vecna')).toBe(false);
+  });
+
+  it('is false when there is no local match at all', () => {
+    expect(check('xyzzy not a character')).toBe(false);
+  });
+
+  it('is false for a null match regardless of message', () => {
+    expect(isWholeMessageMatch(null, 'Trapper')).toBe(false);
   });
 });

--- a/apps/web/src/data/characters.ts
+++ b/apps/web/src/data/characters.ts
@@ -3,4 +3,5 @@ export {
   DEFAULT_CHARACTERS,
   getKillerPortrait,
   tryLocalMatch,
+  isWholeMessageMatch,
 } from '@dbd-utils/shared';

--- a/apps/web/src/services/llm.test.ts
+++ b/apps/web/src/services/llm.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { identifyCharacter } from './llm';
+import type { Request } from '@dbd-utils/shared';
+
+vi.mock('../store/auth', () => ({
+  useAuth: {
+    getState: () => ({ isAuthenticated: true, getAccessToken: async () => 'token' }),
+  },
+}));
+
+function makeRequest(message: string): Request {
+  return {
+    id: 1,
+    timestamp: new Date(),
+    donor: 'Donor',
+    amount: 'R$10',
+    amountVal: 10,
+    message,
+    character: '',
+    type: 'unknown',
+    source: 'donation',
+  };
+}
+
+describe('identifyCharacter — skip LLM when local match is the whole message', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    // Injected by Vite's `define` in the real build; absent under vitest.
+    vi.stubGlobal('__APP_VERSION__', 'test');
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not call the LLM when the matched term is the entire message, even with extras requested', async () => {
+    const result = await identifyCharacter(makeRequest('Trapper'), ['build'], undefined, () => {});
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.character).toBe('Trapper');
+    expect(result.type).toBe('killer');
+    expect(result.validating).toBeUndefined();
+  });
+
+  it('ignores surrounding whitespace and case when comparing match to message', async () => {
+    const result = await identifyCharacter(makeRequest('  trapper  '), ['build'], undefined, () => {});
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.character).toBe('Trapper');
+  });
+
+  it('still calls the LLM for extras when the message has text beyond the character name', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ characters: [{ character: 'Trapper', type: 'killer' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const onLLMUpdate = vi.fn();
+    const result = await identifyCharacter(
+      makeRequest('Trapper com build de mori'),
+      ['build'],
+      undefined,
+      onLLMUpdate
+    );
+
+    expect(result.validating).toBe(true);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/web/src/services/llm.ts
+++ b/apps/web/src/services/llm.ts
@@ -1,4 +1,4 @@
-import { tryLocalMatch } from '../data/characters';
+import { tryLocalMatch, isWholeMessageMatch } from '../data/characters';
 import { useAuth } from '../store/auth';
 import type { Request, RequestExtra, RequestExtraType } from '../types';
 
@@ -77,9 +77,15 @@ export async function identifyCharacter(
   const local = tryLocalMatch(request.message);
   const isAuthenticated = useAuth.getState().isAuthenticated;
 
+  // When the matched term is the entire message (e.g. just "Trapper"), there's no
+  // surrounding text for the LLM to parse — no build, no ambiguity — so the local
+  // match is final and we skip the call even when extras were requested.
+  const matchIsWholeMessage = isWholeMessageMatch(local, request.message);
+
   // Local match alone never carries extras. If the caller asked for extras AND the
   // donation is eligible, we must hit the LLM even when the character matched locally.
-  const needsLLMForExtras = !!local && extras.length > 0 && isAuthenticated && !!onLLMUpdate;
+  const needsLLMForExtras =
+    !!local && extras.length > 0 && isAuthenticated && !!onLLMUpdate && !matchIsWholeMessage;
 
   if (local && !needsLLMForExtras) {
     if (local.ambiguous && isAuthenticated && onLLMUpdate) {

--- a/apps/web/src/services/twitch.test.ts
+++ b/apps/web/src/services/twitch.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handleMessage, setActiveStores } from './twitch';
+import { identifyMultiple } from './llm';
+import type { ChannelStores } from '../store/channel';
+import type { Request } from '@dbd-utils/shared';
+
+vi.mock('./llm', () => ({
+  identifyMultiple: vi.fn(async () => []),
+}));
+
+vi.mock('../store/auth', () => ({
+  useAuth: { getState: () => ({ isAuthenticated: true }) },
+}));
+
+const identifyMultipleMock = vi.mocked(identifyMultiple);
+
+function donationRaw(donor: string, amount: number, message: string): string {
+  return `@display-name=livepix;color=#FF0000 :livepix!livepix@livepix.tmi.twitch.tv PRIVMSG #test :${donor} doou R$ ${amount},00: ${message}`;
+}
+
+describe('handleMessage — above-minimum donation routing', () => {
+  let added: Request[];
+
+  beforeEach(() => {
+    added = [];
+    setActiveStores({
+      useSources: {
+        getState: () => ({
+          enabled: { donation: true },
+          chatCommand: '!fila',
+          minDonation: 5,
+          extrasConfig: undefined,
+        }),
+      },
+      useRequests: {
+        getState: () => ({ add: (r: Request) => added.push(r) }),
+      },
+    } as unknown as ChannelStores);
+  });
+
+  afterEach(() => {
+    identifyMultipleMock.mockClear();
+    setActiveStores(null);
+  });
+
+  it('skips the LLM and adds one local request when an above-min donation is exactly one character', () => {
+    // R$50 with min R$5 → entitlement 10 (multi-request path)
+    handleMessage(donationRaw('Bob', 50, 'Trapper'));
+
+    expect(identifyMultipleMock).not.toHaveBeenCalled();
+    expect(added).toHaveLength(1);
+    expect(added[0].character).toBe('Trapper');
+    expect(added[0].type).toBe('killer');
+    expect(added[0].needsIdentification).toBe(false);
+  });
+
+  it('still calls the LLM when an above-min donation contains more than the character name', () => {
+    handleMessage(donationRaw('Bob', 50, 'Trapper e Nurse'));
+
+    expect(identifyMultipleMock).toHaveBeenCalledTimes(1);
+    expect(identifyMultipleMock).toHaveBeenCalledWith('Trapper e Nurse', 10, expect.anything());
+  });
+
+  it('still calls the LLM when an above-min donation has build text after the character', () => {
+    handleMessage(donationRaw('Bob', 50, 'Trapper com mori'));
+
+    expect(identifyMultipleMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/services/twitch.ts
+++ b/apps/web/src/services/twitch.ts
@@ -1,4 +1,4 @@
-import { tryLocalMatch } from '../data/characters';
+import { tryLocalMatch, isWholeMessageMatch } from '../data/characters';
 import { parseAmount, parseDonationMessage, isDonateBot } from '../utils/helpers';
 import { useSettings } from '../store/settings';
 import { useAuth } from '../store/auth';
@@ -286,6 +286,24 @@ export function handleMessage(raw: string) {
       originMsgId: twitchMsgId || `synthetic:${parsed.donor}:${parsed.amount}:${timestampMs}`,
     };
     addRequest(request);
+    return;
+  }
+
+  // Above-min donation whose whole message is a single unambiguous character
+  // (e.g. donated R$50 and just wrote "Trapper"). Nothing to split or extract —
+  // build one local request and skip the LLM.
+  const wholeMatch = tryLocalMatch(parsed.message);
+  if (isWholeMessageMatch(wholeMatch, parsed.message)) {
+    const built = buildDonationRequests({
+      donor: parsed.donor,
+      amount: parsed.amount,
+      amountVal,
+      message: parsed.message,
+      twitchMsgId,
+      timestampMs,
+      identified: [{ character: wholeMatch!.character, type: wholeMatch!.type, matchedTerm: wholeMatch!.matchedTerm }],
+    });
+    for (const r of built) addRequest(r);
     return;
   }
 

--- a/packages/shared/src/characters.ts
+++ b/packages/shared/src/characters.ts
@@ -171,3 +171,11 @@ export function tryLocalMatch(message: string): LocalMatchResult | null {
         matchedTerm: lastMatch.matchedTerm
     };
 }
+
+// True when the local match is a single unambiguous character whose matched term
+// is the entire message (e.g. "Trapper"). In that case there's nothing else for the
+// LLM to parse — no build text, no extra characters — so the local result is final.
+export function isWholeMessageMatch(local: LocalMatchResult | null, message: string): boolean {
+    return !!local && !local.ambiguous && !!local.matchedTerm &&
+        local.matchedTerm.trim().toLowerCase() === message.trim().toLowerCase();
+}


### PR DESCRIPTION
**Stack 4 of 4** — base: \`split/3-optimistic-queue\` (#26). Merge after #26.

LLM cost/latency optimization, independent of the perf/caching work.

- \`isWholeMessageMatch\`: when a donation/chat message is a single unambiguous character with no surrounding text (e.g. just "Trapper"), the local match is final — skip the LLM call even when extras were requested
- Applied in both the chat/donation path (\`services/twitch.ts\`) and \`identifyCharacter\` (\`services/llm.ts\`)

### Release impact
- Pure runtime behavior; no persisted-data or message-shape changes. Fewer Gemini calls for trivially-matched messages.

New tests: \`services/llm.test.ts\`, \`services/twitch.test.ts\`, plus \`data/characters.test.ts\` cases. Typechecks clean. Final PR in the stack: 1 → 2 → 3 → 4.