### PR TITLE
Add The Life Road chapter survivor (Shane Wiigwaas)

### DIFF
--- a/packages/shared/src/characters.ts
+++ b/packages/shared/src/characters.ts
@@ -54,6 +54,7 @@ export const CHARACTERS: CharacterData = {
         { name: "Dustin Henderson", aliases: [] },
         { name: "Eleven", aliases: ["Jane Hopper", "Onze"] },
         { name: "Kwon Tae-young", aliases: [] },
+        { name: "Shane Wiigwaas", aliases: [] },
         { name: "Aurora Stardotter", aliases: [] },
     ],
     killers: [
@@ -101,6 +102,8 @@ export const CHARACTERS: CharacterData = {
         { name: "The First", aliases: ["First", "Vecna", "Vecna Stranger Things", "Vecna Novo", "One", "Número Um", "Henry Creel"], portrait: "/images/portraits/K42_TheFirst.webp" },
         { name: "Slasher", aliases: ["Jason", "Jason Voorhees", "Voorhees", "Sexta-feira 13", "Friday the 13th"], portrait: "/images/portraits/K43_TheSlasher.webp" },
         { name: "Judgment", aliases: ["Judgement", "Julgamento"], portrait: "/images/portraits/K44_TheJudgment.webp" },
+        { name: "Art the Clown", aliases: ["Art"] },
+        { name: "Champion", aliases: ["Frank Stone", "Franklin Stone", "Campeão"] },
     ]
 };
 

--- a/packages/shared/src/characters.ts
+++ b/packages/shared/src/characters.ts
@@ -102,8 +102,6 @@ export const CHARACTERS: CharacterData = {
         { name: "The First", aliases: ["First", "Vecna", "Vecna Stranger Things", "Vecna Novo", "One", "Número Um", "Henry Creel"], portrait: "/images/portraits/K42_TheFirst.webp" },
         { name: "Slasher", aliases: ["Jason", "Jason Voorhees", "Voorhees", "Sexta-feira 13", "Friday the 13th"], portrait: "/images/portraits/K43_TheSlasher.webp" },
         { name: "Judgment", aliases: ["Judgement", "Julgamento"], portrait: "/images/portraits/K44_TheJudgment.webp" },
-        { name: "Art the Clown", aliases: ["Art"] },
-        { name: "Champion", aliases: ["Frank Stone", "Franklin Stone", "Campeão"] },
     ]
 };
 


### PR DESCRIPTION
## Summary

Scheduled character-base sync found a released character missing from `packages/shared/src/characters.ts`:

- **Shane Wiigwaas** (survivor) — released chapter [The Life Road](https://deadbydaylight.wiki.gg/wiki/The_Life_Road) (June 25, 2026).

Originally this PR also added the announced-but-unreleased killers Art the Clown (Terrifier, Nov 2026) and Champion (Frank Stone, Mar 2027); those were dropped per the updated policy — characters are added only once they're on the PTB or released, since viewers can't request what isn't playable and announced names/titles often change.

## Test plan

- [x] `bun run test` (Vitest, all packages pass)
- [x] `bun run typecheck` (all packages pass)
- [x] `tryLocalMatch('shane wiigwaas')` resolves to the new survivor

🤖 Generated with [Claude Code](https://claude.com/claude-code)